### PR TITLE
v1.5.0: catch-up release for fect 2.4.x

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: gsynth
 Type: Package
 Title: Generalized Synthetic Control Method
-Version: 1.4.0
-Date: 2026-03-27
+Version: 1.5.0
+Date: 2026-05-05
 Authors@R:
   c(person("Yiqing", "Xu", ,"yiqingxu@stanford.edu", role = c("aut", "cre"),
   comment = c(ORCID = "0000-0003-2041-6671")),
@@ -27,9 +27,9 @@ BugReports: https://github.com/xuyiqing/gsynth/issues
 NeedsCompilation: no
 Encoding: UTF-8
 License: MIT + file LICENSE
-Imports: ggplot2 (>= 2.1.0), fect (>= 2.0.0), panelView (>= 1.1.17)
+Imports: ggplot2 (>= 2.1.0), fect (>= 2.4.2), panelView (>= 1.1.17)
 Suggests: testthat (>= 3.0.0)
 Depends: R (>= 2.10)
 LazyData: true
 Config/testthat/edition: 3
-RoxygenNote: 7.3.2
+RoxygenNote: 7.3.3

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,15 @@
+# gsynth 1.5.0
+
+* **New: placebo test**. Arguments `placeboTest = TRUE` and `placebo.period` (e.g. `c(-2, 0)`) hold out pre-treatment periods as a placebo region. Introduced in `vignette("01-gsynth", package = "gsynth")` §Placebo test, applied to IFE-EM and matrix completion in `vignette("02-ife-mc", package = "gsynth")`. (`gsynth()` does not expose `carryoverTest`: the GSC framework does not allow treatment reversals, which fect's carryover test requires. Use `fect::fect()` directly for carryover diagnostics on reversal-friendly panels.)
+* **New: `ci.method` argument on `gsynth()`**. `"normal"` (default; Wald: point ± z × SE) or `"basic"` (reflected-pivot bootstrap interval, Davison and Hinkley 1997). The point estimate and SE are unaffected by the choice; only the CI columns differ. New in fect v2.4.2.
+* **New: loading-overlap plot type** for the GSC estimator. `plot(fit, type = "loading.overlap")` shows treated and control loadings in the first two factor dimensions, with the convex hull of control loadings shaded; treated points outside the hull indicate the GSC counterfactual is extrapolating. See `vignette("01-gsynth", package = "gsynth")` §Loading-overlap diagnostic.
+* **New: modern plot recipe** (from **fect** 2.3.x). New `plot.gsynth()` arguments `legacy.style = FALSE`, `highlight = NULL`, `highlight.fill = FALSE`. The pre-2.3 visual recipe is reproducible with `legacy.style = TRUE`.
+* **New: per-role weight arguments** `W.est` (outcome-model fit) and `W.agg` (aggregation), plus `weight = ...` continues to apply to both roles. From **fect** 2.3.1.
+* **New: rolling-window CV is now the default**. New arguments `cv.method = "rolling"` (default; pass `"block"` for the pre-v1.5 design), `cv.prop = 0.1`, `cv.buffer = 1`. The default `k` is flipped from 5 to 20. From **fect** 2.3.0.
+* **Breaking change**: `inference = "parametric"` combined with `estimator = "ife"` or `estimator = "mc"` now errors instead of silently falling back to nonparametric bootstrap. This aligns gsynth's wrapper with **fect** v2.2.0's hard gate. Migrate to `inference = "bootstrap"` or `inference = "jackknife"` for those estimators.
+* **Soft-deprecated**: `estimator = "ife"`, `estimator = "mc"`, `EM = TRUE`, and `effect()`. Each emits a one-time-per-session console message pointing to the recommended replacement. Removal is targeted for v2.0.0. **For IFE-EM, matrix completion, or post-hoc estimands (cumulative ATT, APTT, log-ATT), use [`fect::fect()`](https://yiqingxu.org/packages/fect/) and `fect::estimand()` directly.** See `vignette("02-ife-mc", package = "gsynth")` for migration recipes.
+* **Dependency**: `fect (>= 2.4.2)`.
+
 # gsynth 1.4.0
 
 * **Breaking change**: The `estimator` parameter now maps directly to estimation methods. `estimator = "gsynth"` (new default) uses the generalized synthetic control method (Xu 2017); `estimator = "ife"` uses the IFE-EM algorithm (Gobillon & Magnac 2016); `estimator = "mc"` uses matrix completion (Athey et al. 2021). The legacy `EM = TRUE` parameter is equivalent to `estimator = "ife"` when `estimator` is not explicitly specified.

--- a/R/default.R
+++ b/R/default.R
@@ -1,9 +1,6 @@
 ## Synthetic Control for Multiple Treated Units
 ## (Causal Inference with Interactive Fixed Effects Models)
-## Version
-## Authors: Yiqing Xu, University of California, San Diego; Licheng Liu (Thu)
-## Last Modified by Shiyun Hu
-## Date: 2025.2.11
+## Authors: Yiqing Xu, Stanford University; Licheng Liu; Ziyi Liu; Shiyun Hu
 
 ## MAIN FUNCTION
 ## gsynth.default()
@@ -16,12 +13,33 @@
 ## plot.gsynth()
 
 #####################################################################
+## Soft-deprecation message infrastructure
+#####################################################################
+
+## Each deprecation key fires once per session.
+.gsynth_deprecation_seen <- local({
+    seen <- character(0)
+    function(key) {
+        if (key %in% seen) return(invisible(FALSE))
+        seen <<- c(seen, key)
+        invisible(TRUE)
+    }
+})
+
+.deprecation_message <- function(key, msg) {
+    if (.gsynth_deprecation_seen(key)) {
+        packageStartupMessage(msg)
+    }
+    invisible(NULL)
+}
+
+#####################################################################
 ## A Shell Function
 #####################################################################
 
 ## default function
 
-gsynth <- function(formula = NULL,data, # a data frame (long-form)
+gsynth <- function(formula = NULL, data, # a data frame (long-form)
                            Y, # outcome
                            D, # treatment
                            X = NULL, # time-varying covariates
@@ -30,65 +48,159 @@ gsynth <- function(formula = NULL,data, # a data frame (long-form)
                            weight = NULL,
                            force = "unit", # fixed effects demeaning
                            cl = NULL,
-                           r = 0, # nubmer of factors
+                           r = 0, # number of factors
                            lambda = NULL, ## mc method: regularization parameter
                            nlambda = 10, ## mc method: regularization parameter
                            CV = TRUE, # cross-validation
                            criterion = "mspe", # mspe or pc
-                           k = 5, # cross-validation times
-                           EM = FALSE, # EM algorithm (legacy; use estimator = "ife" instead)
+                           k = 20, # cross-validation folds (was 5 in v1.4.0)
+                           cv.method = "rolling", # NEW: "rolling" or "block"
+                           cv.prop = 0.1, # NEW: per-fold unit-sampling fraction
+                           cv.buffer = 1, # NEW: past-side buffer for rolling CV
+                           EM = FALSE, # legacy; use estimator = "ife" instead
                            estimator = "gsynth", # gsynth/ife/mc method
+                           time.component.from = NULL, # NEW: NULL lets fect dispatch by estimator
                            se = FALSE, # report uncertainties
                            nboots = 200, # number of bootstraps
                            inference = NULL, # type of inference
-                           # cov.ar = 1,
                            parallel = TRUE, # parallel computing
                            cores = NULL, # number of cores
                            tol = 0.001, # tolerance level
                            seed = NULL, # set seed
                            min.T0 = 5,
                            alpha = 0.05,
-                           normalize = FALSE
+                           normalize = FALSE,
+                           W.est = NULL, # NEW: per-role weight (estimation)
+                           W.agg = NULL, # NEW: per-role weight (aggregation)
+                           ci.method = "normal", # NEW (v1.5.0): "normal" (Wald) or "basic" (reflected pivot) for est.* slots
+                           placeboTest = FALSE, # NEW (v1.5.0): hold out pre-treatment periods as placebo
+                           placebo.period = NULL # NEW (v1.5.0): event-time periods to use for placebo (e.g., c(-2, 0))
                            ) {
-    ## Method routing
+
+    ##-------------------------------##
+    ## Method routing (with soft-deprecation for non-GSC paths)
+    ##-------------------------------##
+
     ## estimator = "gsynth" -> Xu (2017): factors from control group only
-    ## estimator = "ife"    -> Gobillon & Magnac (2016): EM using treated pre-treatment
+    ## estimator = "ife"    -> Gobillon & Magnac (2016): EM using treated pre-treatment data
     ## estimator = "mc"     -> Athey et al. (2021): matrix completion
     ## EM = TRUE (legacy)   -> same as estimator = "ife"
+    ##
+    ## In gsynth v1.5.0, estimator %in% c("ife", "mc") and EM = TRUE are
+    ## SOFT-DEPRECATED. Each fires a one-time-per-session message pointing
+    ## the user to fect::fect(). Removal is targeted for v2.0.0.
+
     method <- estimator
-    if (EM == TRUE && missing(estimator)) {
+    if (isTRUE(EM) && missing(estimator)) {
         method <- "ife" # legacy backward compatibility
+        .deprecation_message(
+            key = "EM_TRUE",
+            msg = paste0(
+                "gsynth(EM = TRUE): soft-deprecated in v1.5.0, ",
+                "removal in v2.0.0. ",
+                "Use fect::fect(method = \"ife\", ",
+                "time.component.from = \"notyettreated\", ...) directly. ",
+                "See vignette(\"02-ife-mc\", package = \"gsynth\")."
+            )
+        )
     }
-    if (is.null(inference) == TRUE) {
-      if (method %in% c("ife", "mc")) {
-        inference <- "bootstrap"
-      } else { # gsynth
-        inference <- "parametric"
-      }
+
+    if (method == "ife") {
+        .deprecation_message(
+            key = "estimator_ife",
+            msg = paste0(
+                "gsynth(estimator = \"ife\"): soft-deprecated in v1.5.0, ",
+                "removal in v2.0.0. ",
+                "For IFE-EM, use fect::fect(method = \"ife\", ",
+                "time.component.from = \"notyettreated\", ...) directly. ",
+                "See vignette(\"02-ife-mc\", package = \"gsynth\") ",
+                "for migration recipes."
+            )
+        )
+    }
+    if (method == "mc") {
+        .deprecation_message(
+            key = "estimator_mc",
+            msg = paste0(
+                "gsynth(estimator = \"mc\"): soft-deprecated in v1.5.0, ",
+                "removal in v2.0.0. ",
+                "For matrix completion, use fect::fect(method = \"mc\", ",
+                "time.component.from = \"notyettreated\", ...) directly. ",
+                "See vignette(\"02-ife-mc\", package = \"gsynth\") ",
+                "for migration recipes."
+            )
+        )
+    }
+
+    ##-------------------------------##
+    ## Inference routing
+    ##-------------------------------##
+
+    ## v1.5.0 behavior: do NOT silently coerce inference = "parametric"
+    ## to "bootstrap" for IFE-EM / MC. fect's hard gate (v2.2.0+) errors
+    ## on this combination, and the wrapper passes the error through.
+    ##
+    ## Public commitment: gsynth-note (Xu 2026), Appendix A.5 ("Hard gate
+    ## on IFE-EM + parametric") states that this combination must error
+    ## rather than auto-fallback, on the grounds that silent coercion
+    ## would mask the inferential issue from analysts who deliberately
+    ## chose IFE-EM.
+
+    if (is.null(inference)) {
+        if (method %in% c("ife", "mc")) {
+            inference <- "bootstrap"
+        } else { # gsynth
+            inference <- "parametric"
+        }
     }
     if (inference == "nonparametric") {
-      inference <- "bootstrap"
-    }
-    if (method %in% c("ife", "mc")) {
-      if (inference == "parametric") {
         inference <- "bootstrap"
-        warning("Using nonparametric bootstrap for inference with EM/MC method.")
-      }
     }
-    output <- fect::fect(formula = formula, data = data, method = method, Y = Y, D = D, X = X,
+
+    ##-------------------------------##
+    ## time.component.from: route by estimator if not explicitly set
+    ##-------------------------------##
+
+    ## "gsynth" -> nevertreated (factor estimation on controls only;
+    ##   the GSC objective).
+    ## "ife" / "mc" -> notyettreated (factor estimation includes treated
+    ##   pre-treatment cells via EM imputation).
+    if (is.null(time.component.from)) {
+        time.component.from <- if (method == "gsynth") {
+            "nevertreated"
+        } else {
+            "notyettreated"
+        }
+    }
+
+    ##-------------------------------##
+    ## Pass-through to fect::fect()
+    ##-------------------------------##
+
+    output <- fect::fect(
+        formula = formula, data = data, method = method,
+        Y = Y, D = D, X = X,
         na.rm = na.rm, index = index, cl = cl,
-        force = force, r = r, lambda = lambda, nlambda = nlambda, CV = CV,
-        criterion = criterion, k = k, se = se, nboots = nboots, vartype = inference,
-        parallel = parallel, cores = cores, tol = tol, seed = seed, min.T0 = min.T0,
-        alpha = alpha, normalize = normalize, keep.sims = TRUE)
+        force = force, r = r, lambda = lambda, nlambda = nlambda,
+        CV = CV, criterion = criterion, k = k,
+        cv.method = cv.method, cv.prop = cv.prop, cv.buffer = cv.buffer,
+        time.component.from = time.component.from,
+        se = se, nboots = nboots, vartype = inference,
+        ci.method = ci.method,
+        placeboTest = placeboTest, placebo.period = placebo.period,
+        parallel = parallel, cores = cores, tol = tol, seed = seed,
+        min.T0 = min.T0, alpha = alpha, normalize = normalize,
+        W = weight, W.est = W.est, W.agg = W.agg,
+        keep.sims = TRUE
+    )
 
     ##-------------------------------##
-    ## storage
+    ## Storage
     ##-------------------------------##
 
-    output$call = match.call()
-    output$call$vartype <- output$call$inference # Name is compatible with `fect`
-    output$data <- data # Save origninal long-form data, to utilize panelView
+    output$call <- match.call()
+    output$call$vartype <- output$call$inference # Name compatible with fect
+    output$data <- data # Save original long-form data, to utilize panelView
     class(output) <- "gsynth"
     return(output)
 

--- a/R/effect.R
+++ b/R/effect.R
@@ -1,5 +1,9 @@
 # Calculate cumulative average treatment effect or group effects
 # A wrapper function of fect:::cumuEff
+#
+# Soft-deprecated in v1.5.0. For new code, class-munge the gsynth fit
+# to "fect" and call fect::estimand(fit, "att.cumu", ...). Removal not
+# before gsynth v2.0.0.
 #' @import fect
 #' @param x A `fect` object with `method="gsynth"`.
 #' @param cumu Boolean, whether to calculate cumulative ATT.
@@ -9,6 +13,15 @@
 #' @return Cumulative effects
 #' @export
 effect <- function(x, cumu=TRUE, period=NULL, id=NULL, plot=FALSE){
+  .deprecation_message(
+    key = "effect",
+    msg = paste0(
+      "effect(): soft-deprecated in v1.5.0. ",
+      "For new code, class-munge the gsynth fit to \"fect\" ",
+      "and call fect::estimand(fit, \"att.cumu\", ...) directly. ",
+      "Removal not before gsynth v2.0.0."
+    )
+  )
   out <- fect::effect(x=x, cumu=cumu, period=period, id=id, plot=plot)
   return(out)
 }

--- a/R/plot.R
+++ b/R/plot.R
@@ -26,6 +26,9 @@ plot.gsynth <- function(
     axis.adjust = FALSE,
     theme.bw = TRUE,
     shade.post = FALSE,
+    legacy.style = FALSE,
+    highlight = NULL,
+    highlight.fill = FALSE,
     ...){
 
   if (type %in% c("raw","missing")){
@@ -90,6 +93,9 @@ plot.gsynth <- function(
       axis.adjust = axis.adjust,
       theme.bw=theme.bw,
       shade.post = shade.post,
+      legacy.style = legacy.style,
+      highlight = highlight,
+      highlight.fill = highlight.fill,
         ...)
     return(p)
   }

--- a/R/zzz.r
+++ b/R/zzz.r
@@ -1,6 +1,9 @@
 .onAttach <-
 function (libname, pkgname){
    # echo output to screen
-   packageStartupMessage("## v1.4.0: estimator='ife' now uses the EM algorithm; default is 'gsynth'. See ?gsynth.")
-   packageStartupMessage("## Since v.1.3.0, *gsynth* is a wrapper of the *fect* package.")
+   packageStartupMessage("## gsynth v1.5.0 (requires fect >= 2.4.2).")
+   packageStartupMessage("## *gsynth* is a wrapper of the *fect* package; see ?gsynth.")
+   packageStartupMessage("## NOTE: estimator='ife' and estimator='mc' are soft-deprecated in v1.5.0;")
+   packageStartupMessage("##   for IFE-EM or matrix completion, use fect::fect() directly.")
+   packageStartupMessage("##   See vignette('02-ife-mc', package='gsynth').")
 }

--- a/man/effect.rd
+++ b/man/effect.rd
@@ -1,7 +1,15 @@
 \name{effect}
 \alias{effect}
 \title{Cumulative or Sub-group Treatment Effects}
-\description{Calculates cumulative or sub-group treatment effects}
+\description{Calculates cumulative or sub-group treatment effects.
+
+  \strong{Soft-deprecated in v1.5.0}: for cumulative or sub-group
+  estimands, use \code{\link[fect]{estimand}} from \pkg{fect} (v2.4.0+).
+  After class-munging the gsynth fit to \code{"fect"}, call
+  \code{fect::estimand(fit, "att.cumu", ...)}. Each call to
+  \code{effect()} emits a one-time-per-session message. Removal not
+  before gsynth v2.0.0.
+}
 \usage{effect(x, cumu = TRUE, period = NULL, id = NULL, plot = FALSE)}
 \arguments{
   \item{x}{a \code{\link{gsynth}} object.}
@@ -26,7 +34,7 @@
   Iss. 1, January 2017, pp. 57-76.
 }
 \seealso{
-  \code{\link{gsynth}}
+  \code{\link{gsynth}}, \code{\link[fect]{estimand}}.
 }
 
 

--- a/man/gsynth.Rd
+++ b/man/gsynth.Rd
@@ -3,14 +3,18 @@
 \title{Generalized Synthetic Control Method}
 \description{Implements the generalized synthetic control method based
 on interactive fixed effect models.}
-\usage{gsynth(formula=NULL, data, Y, D, X = NULL, na.rm = FALSE,
+\usage{gsynth(formula = NULL, data, Y, D, X = NULL, na.rm = FALSE,
        index, weight = NULL, force = "unit", cl = NULL, r = 0,
        lambda = NULL, nlambda = 10, CV = TRUE, criterion = "mspe",
-       k = 5, EM = FALSE, estimator = "gsynth",
+       k = 20, cv.method = "rolling", cv.prop = 0.1, cv.buffer = 1,
+       EM = FALSE, estimator = "gsynth", time.component.from = NULL,
        se = FALSE, nboots = 200,
        inference = NULL, parallel = TRUE,
        cores = NULL, tol = 0.001, seed = NULL, min.T0 = 5,
-       alpha = 0.05, normalize = FALSE)
+       alpha = 0.05, normalize = FALSE,
+       W.est = NULL, W.agg = NULL,
+       ci.method = "normal",
+       placeboTest = FALSE, placebo.period = NULL)
 }
 \arguments{
 \item{formula}{an object of class "formula": a symbolic description of
@@ -25,8 +29,10 @@ on interactive fixed effect models.}
   exist.}
 \item{index}{a two-element string vector specifying the unit (group)
     and time indicators. Must be of length 2.}
-\item{weight}{a string specifying the weighting variable(if any) to estimate
-    the weighted average treatment effect. Default is \code{weight = NULL}.}
+\item{weight}{a string specifying the weighting variable (if any) to
+    estimate the weighted average treatment effect. Default is
+    \code{weight = NULL}. Applies to both estimation and aggregation
+    roles. For per-role control, use \code{W.est} and \code{W.agg}.}
 \item{force}{a string indicating whether unit or time fixed effects will be
     imposed. Must be one of the following,
     "none", "unit", "time", or "two-way". The default is "unit".}
@@ -50,21 +56,47 @@ on interactive fixed effect models.}
   prediction error obtained through the loocv procedure, and "pc" stands for a kind
   of information criterion. If \code{criterion = "pc"}, the number of factors that
   minimize "pc" will be selected. Default is \code{criterion = "mspe"}.}
-\item{k}{a positive integer specifying cross-validation times for matrix
- completion algorithm. Default is \code{k = 5}.}
+\item{k}{a positive integer specifying the number of cross-validation folds.
+  Default is \code{k = 20} (changed from \code{k = 5} in v1.5.0 to align with
+  \code{fect} v2.3.0+ defaults).}
+\item{cv.method}{a string specifying the cross-validation masking strategy.
+  Either \code{"rolling"} (default; rolling-window CV introduced in
+  \code{fect} v2.3.0) or \code{"block"} (the pre-v1.5.0 design, retained
+  for replication). New in v1.5.0.}
+\item{cv.prop}{numeric. Fraction of eligible units sampled per fold under
+  rolling CV (proportion of observations masked per round under block CV).
+  Default \code{0.1}. New in v1.5.0.}
+\item{cv.buffer}{integer. Past-side buffer (in time periods) for
+  \code{cv.method = "rolling"}. Default \code{1}. New in v1.5.0.}
 \item{EM}{a logical flag indicating whether an Expectation Maximization
-  algorithm will be used (Gobillon and Magnac 2016).}
-\item{estimator}{a string that controls the estimation method: \code{"gsynth"}
-(generalized synthetic control, default), \code{"ife"} (interactive fixed effects
-with EM algorithm), or \code{"mc"} (matrix completion method).}
+  algorithm will be used (Gobillon and Magnac 2016). Soft-deprecated in
+  v1.5.0; equivalent to \code{estimator = "ife"}. Removal targeted for
+  v2.0.0. For IFE-EM, use \code{fect::fect(method = "ife", ...)} directly.}
+\item{estimator}{a string that controls the estimation method:
+  \code{"gsynth"} (generalized synthetic control, default), \code{"ife"}
+  (interactive fixed effects with EM algorithm), or \code{"mc"} (matrix
+  completion method). \code{"ife"} and \code{"mc"} are soft-deprecated in
+  v1.5.0; removal targeted for v2.0.0. For IFE-EM or matrix completion,
+  use \code{fect::fect(method = "ife", ...)} or
+  \code{fect::fect(method = "mc", ...)} directly.}
+\item{time.component.from}{a string specifying the sample for factor
+  estimation: \code{"nevertreated"} (control units only; the GSC objective)
+  or \code{"notyettreated"} (includes treated-unit pre-treatment cells).
+  Default \code{NULL} routes by \code{estimator}: \code{"gsynth"} maps to
+  \code{"nevertreated"}; \code{"ife"} and \code{"mc"} map to
+  \code{"notyettreated"}. New in v1.5.0.}
 \item{se}{a logical flag indicating whether uncertainty estimates will
   be produced.}
 \item{nboots}{an integer specifying the number of bootstrap
   runs. Ignored if \code{se = FALSE}.}
 \item{inference}{a string specifying which type of inferential method
-  will be used, either "parametric" or "nonparametric". "parametric" is
-  recommended when the number of treated units is small. parametric bootstrap
-  is not valid for matrix completion method. Ignored if \code{estimator = "mc"}.}
+  will be used: \code{"parametric"}, \code{"nonparametric"}, or
+  \code{"jackknife"}. \code{"parametric"} is recommended when the number of
+  treated units is small and is only valid for \code{estimator = "gsynth"}.
+  \strong{Breaking change in v1.5.0:} \code{inference = "parametric"} with
+  \code{estimator = "ife"} or \code{"mc"} now errors instead of silently
+  falling back to nonparametric bootstrap, aligning with the hard gate in
+  \code{fect} v2.2.0+ and the public commitment in Xu (2026), Appendix A.5.}
 \item{parallel}{a logical flag indicating whether parallel computing
   will be used in bootstrapping and/or cross-validation. Ignored if
   \code{se = FALSE}.}
@@ -88,6 +120,40 @@ with EM algorithm), or \code{"mc"} (matrix completion method).}
 \item{normalize}{a logic flag indicating whether to scale outcome and
   covariates. Useful for accelerating computing speed when magnitude of
   data is large. The default is \code{normalize=FALSE}.}
+\item{W.est}{a string specifying the weighting column for the
+  outcome-model fit (per-role weight). Overrides \code{weight} for that
+  role. From \code{fect} v2.3.1; new in gsynth v1.5.0.}
+\item{W.agg}{a string specifying the weighting column for the ATT
+  aggregation step (per-role weight). Overrides \code{weight} for that
+  role. From \code{fect} v2.3.1; new in gsynth v1.5.0.}
+\item{ci.method}{a string controlling the confidence-interval method
+  used for the \code{est.*} slots. \code{"normal"} (default) uses Wald
+  intervals (\eqn{\hat{\theta} \pm z_{1-\alpha/2}\,\widehat{\mathrm{SE}}});
+  \code{"basic"} uses the reflected-pivot bootstrap interval (Davison and
+  Hinkley 1997, Sec. 5.2.1) when \code{inference = "bootstrap"} or
+  \code{"jackknife"}. For percentile, BC, and BCa intervals on
+  alternative estimands (cumulative ATT, APTT, log-ATT), call
+  \code{\link[fect]{estimand}} on the fit object after class-munging
+  to \code{"fect"}. New in v1.5.0 (forwards \code{fect}'s
+  \code{ci.method}, added in fect v2.4.2).}
+\item{placeboTest}{a logical flag. If \code{TRUE}, a contiguous block of
+  pre-treatment periods specified by \code{placebo.period} is held out
+  from estimation and used as a placebo region. The fitted ATT is
+  reported on the placebo periods, allowing the analyst to check
+  whether the estimator produces non-zero "effects" in periods where
+  no effect should exist. New in v1.5.0; forwards \code{fect}'s
+  \code{placeboTest}.}
+\item{placebo.period}{an integer vector specifying which event-time
+  periods to use as the placebo block. For example,
+  \code{placebo.period = c(-2, 0)} treats event-times \eqn{-2} through
+  \eqn{0} as placebo. Default \code{NULL} lets \code{fect} pick a
+  sensible default (typically the two periods immediately preceding
+  treatment). Ignored unless \code{placeboTest = TRUE}.
+
+  \pkg{gsynth} does not expose \code{fect}'s \code{carryoverTest}.
+  The carryover test requires panels with treatment reversals, which
+  the GSC estimator does not allow. For carryover diagnostics on
+  reversal-friendly panels, use \code{\link[fect]{fect}} directly.}
 }
 \details{
   \code{gsynth} implements the generalized synthetic control method. It
@@ -101,6 +167,14 @@ with EM algorithm), or \code{"mc"} (matrix completion method).}
   reasonable modeling assumptions. With a built-in cross-validation
   procedure, it avoids specification searches and thus is easy to
   implement. Data must be with a dichotomous treatment.
+
+  \strong{Note (v1.5.0).} The \code{estimator = "ife"} (Gobillon-Magnac
+  IFE-EM) and \code{estimator = "mc"} (matrix completion) paths are
+  soft-deprecated in this release; each call emits a one-time-per-session
+  message. For IFE-EM or matrix completion, use \code{fect::fect()}
+  directly with \code{method = "ife"} or \code{method = "mc"} and
+  \code{time.component.from = "notyettreated"}. Removal is targeted for
+  gsynth v2.0.0. See \code{vignette("02-ife-mc", package = "gsynth")}.
 }
 \value{
   \item{Y.dat}{a matrix storing data of the outcome variable.}
@@ -192,12 +266,15 @@ with EM algorithm), or \code{"mc"} (matrix completion method).}
 
   Athey S, Bayati M, Doudchenko N, et al. Matrix completion methods for causal panel data models[J]. arXiv preprint arXiv:1710.10251, 2017.
 
+  Yiqing Xu. 2026. "A Response to Green and Aronow."
+
   For more details, see \url{https://yiqingxu.org/packages/gsynth/}.
 
   For more details about the matrix completion method, see \url{https://github.com/susanathey/MCPanel}.
 }
 \seealso{
-  \code{\link{plot.gsynth}} and \code{\link{print.gsynth}}
+  \code{\link{plot.gsynth}}, \code{\link{print.gsynth}},
+  \code{\link[fect]{fect}}.
 }
 \examples{
 library(gsynth)
@@ -207,5 +284,3 @@ out <- gsynth(Y ~ D + X1 + X2, data = simdata, parallel = FALSE,
               CV = TRUE, r = c(0, 5), se = FALSE)
 print(out)
 }
-
-

--- a/man/plot.gsynth.Rd
+++ b/man/plot.gsynth.Rd
@@ -5,7 +5,9 @@
 \usage{\method{plot}{gsynth}(x, type = "gap", xlim = NULL, ylim = NULL,
             xlab = NULL, ylab = NULL, legendOff = FALSE, raw = "none",
             main = NULL, nfactors = NULL, id = NULL, axis.adjust = FALSE,
-            theme.bw = TRUE, shade.post = FALSE, \dots)
+            theme.bw = TRUE, shade.post = FALSE,
+            legacy.style = FALSE, highlight = NULL, highlight.fill = FALSE,
+            \dots)
 }
 \arguments{
   \item{x}{a \code{\link{gsynth}} object.}
@@ -14,7 +16,11 @@
     the treated; "raw" (plotting the raw data); "counterfactual", or "ct" for short,
     (plotting predicted Y(0)'s); "factors" (plotting estimated factors);
     "loadings" (plotting the distribution of estimated factor
-    loadings); "missing" (plotting status of each unit at each time point).}
+    loadings); "loading.overlap" (a diagnostic scatter of treated- and
+    control-unit loadings in the first two factor dimensions, with the
+    convex hull of control loadings shaded; new in v1.5.0, useful for
+    GSC overlap diagnostics); "missing" (plotting status of each unit at
+    each time point).}
   \item{xlim}{a two-element numeric vector specifying the range of x-axis. When
     class of time variable is string, must specify not original value but a
     counting number e.g. \code{xlim=c(1,30)}.}
@@ -42,6 +48,19 @@
     Useful when class of time variable is string and data magnitude is large.}
   \item{theme.bw}{a logical flag indicating whether to use a black/white theme.}
   \item{shade.post}{a logical flag controlling whether to shade the post-treatment periods.}
+  \item{legacy.style}{a logical flag (default \code{FALSE}). When \code{TRUE},
+    reproduces the pre-v1.5.0 visual recipe (legacy axis text sizes, colors,
+    and plot elements). Useful for byte-identical rendering of figures
+    embedded in papers under review. New in v1.5.0.}
+  \item{highlight}{controls which test-period types receive colored-glyph
+    highlighting. \code{NULL} (default) auto-detects from the fit;
+    \code{TRUE}/\code{FALSE} enables/disables across all types; or a character
+    subset of \code{c("placebo", "carryover", "carryover.rm")} to highlight
+    selected types only. New in v1.5.0.}
+  \item{highlight.fill}{a logical flag (default \code{FALSE}). When \code{TRUE},
+    draws a lightened-tone background rectangle behind each highlighted
+    period (slide / talk style). Default \code{FALSE} keeps the glyph-only
+    minimal look. New in v1.5.0.}
   \item{\dots}{other argv.}
 }
 \details{

--- a/tests/testthat/test-ci-method.R
+++ b/tests/testthat/test-ci-method.R
@@ -1,0 +1,90 @@
+# Tests for the v1.5.0 ci.method argument on gsynth()
+# (forwards fect's ci.method, added in fect v2.4.2).
+
+data(simdata, package = "gsynth")
+
+test_that("ci.method = 'normal' produces Wald CIs (point +/- z * SE)", {
+  skip_on_cran()
+  set.seed(11)
+  out <- gsynth(Y ~ D + X1 + X2, data = simdata,
+                index = c("id", "time"), force = "two-way",
+                CV = FALSE, r = 2, se = TRUE,
+                inference = "bootstrap", nboots = 100,
+                ci.method = "normal", parallel = FALSE)
+  ## CI bounds should be symmetric around the point estimate up to
+  ## numerical noise: lo + hi - 2 * point ~ 0.
+  est <- out$est.att
+  midpoint <- (est[, "CI.lower"] + est[, "CI.upper"]) / 2
+  expect_true(all(abs(midpoint - est[, "ATT"]) < 1e-8))
+})
+
+test_that("ci.method = 'basic' produces non-Wald CIs that differ from normal", {
+  skip_on_cran()
+  set.seed(11)
+  out_normal <- gsynth(Y ~ D + X1 + X2, data = simdata,
+                       index = c("id", "time"), force = "two-way",
+                       CV = FALSE, r = 2, se = TRUE,
+                       inference = "bootstrap", nboots = 100,
+                       ci.method = "normal", parallel = FALSE)
+  set.seed(11)
+  out_basic  <- suppressWarnings(
+    gsynth(Y ~ D + X1 + X2, data = simdata,
+           index = c("id", "time"), force = "two-way",
+           CV = FALSE, r = 2, se = TRUE,
+           inference = "bootstrap", nboots = 100,
+           ci.method = "basic", parallel = FALSE)
+  )
+  ## Same point estimates and SEs (those don't depend on ci.method).
+  expect_equal(out_normal$est.att[, "ATT"],  out_basic$est.att[, "ATT"])
+  expect_equal(out_normal$est.att[, "S.E."], out_basic$est.att[, "S.E."])
+  ## CIs should differ on at least one event time.
+  expect_false(isTRUE(all.equal(out_normal$est.att[, "CI.lower"],
+                                out_basic$est.att[, "CI.lower"])))
+})
+
+test_that("ci.method default is 'normal' (matches fect default)", {
+  skip_on_cran()
+  set.seed(11)
+  out_default <- gsynth(Y ~ D + X1 + X2, data = simdata,
+                        index = c("id", "time"), force = "two-way",
+                        CV = FALSE, r = 2, se = TRUE,
+                        inference = "bootstrap", nboots = 100,
+                        parallel = FALSE)
+  set.seed(11)
+  out_normal  <- gsynth(Y ~ D + X1 + X2, data = simdata,
+                        index = c("id", "time"), force = "two-way",
+                        CV = FALSE, r = 2, se = TRUE,
+                        inference = "bootstrap", nboots = 100,
+                        ci.method = "normal", parallel = FALSE)
+  expect_equal(out_default$est.att, out_normal$est.att)
+})
+
+test_that("invalid ci.method is caught by fect", {
+  skip_on_cran()
+  expect_error(
+    gsynth(Y ~ D + X1 + X2, data = simdata,
+           index = c("id", "time"), force = "two-way",
+           CV = FALSE, r = 2, se = TRUE,
+           inference = "bootstrap", nboots = 50,
+           ci.method = "not-a-method", parallel = FALSE)
+  )
+})
+
+test_that("ci.method does not change SE / point estimate", {
+  skip_on_cran()
+  set.seed(11)
+  out_normal <- gsynth(Y ~ D + X1 + X2, data = simdata,
+                       index = c("id", "time"), force = "two-way",
+                       CV = FALSE, r = 2, se = TRUE,
+                       inference = "bootstrap", nboots = 100,
+                       ci.method = "normal", parallel = FALSE)
+  set.seed(11)
+  out_basic <- suppressWarnings(
+    gsynth(Y ~ D + X1 + X2, data = simdata,
+           index = c("id", "time"), force = "two-way",
+           CV = FALSE, r = 2, se = TRUE,
+           inference = "bootstrap", nboots = 100,
+           ci.method = "basic", parallel = FALSE)
+  )
+  expect_equal(out_normal$att, out_basic$att)
+})

--- a/tests/testthat/test-gsynth.R
+++ b/tests/testthat/test-gsynth.R
@@ -21,9 +21,11 @@ test_that("gsynth() default method returns valid object without SE", {
 
 test_that("gsynth() EM method returns valid object", {
   skip_on_cran()
-  out <- gsynth(Y ~ D + X1 + X2, data = simdata,
-                index = c("id", "time"), EM = TRUE, se = FALSE,
-                r = 2, parallel = FALSE)
+  out <- suppressPackageStartupMessages(
+    gsynth(Y ~ D + X1 + X2, data = simdata,
+           index = c("id", "time"), EM = TRUE, se = FALSE,
+           r = 2, parallel = FALSE)
+  )
 
   expect_s3_class(out, "gsynth")
   expect_equal(out$method, "ife")
@@ -31,9 +33,11 @@ test_that("gsynth() EM method returns valid object", {
 
 test_that("gsynth() MC method returns valid object", {
   skip_on_cran()
-  out <- gsynth(Y ~ D + X1 + X2, data = simdata,
-                index = c("id", "time"), estimator = "mc",
-                se = FALSE, parallel = FALSE)
+  out <- suppressPackageStartupMessages(
+    gsynth(Y ~ D + X1 + X2, data = simdata,
+           index = c("id", "time"), estimator = "mc",
+           se = FALSE, parallel = FALSE)
+  )
 
   expect_s3_class(out, "gsynth")
   expect_equal(out$method, "mc")
@@ -54,7 +58,7 @@ test_that("gsynth() with parametric SE returns uncertainty estimates", {
 
 test_that("gsynth() with EM + SE uses bootstrap by default", {
   skip_on_cran()
-  out <- expect_no_warning(
+  out <- suppressPackageStartupMessages(
     gsynth(Y ~ D + X1 + X2, data = simdata,
            index = c("id", "time"), EM = TRUE, se = TRUE,
            nboots = 50, r = 2, parallel = FALSE)
@@ -63,16 +67,19 @@ test_that("gsynth() with EM + SE uses bootstrap by default", {
   expect_equal(out$vartype, "bootstrap")
 })
 
-test_that("gsynth() EM + parametric inference produces override warning", {
+# v1.5.0 BREAKING CHANGE: parametric × IFE-EM/MC was previously coerced
+# to bootstrap with a warning. It now errors via fect's hard gate.
+# See gsynth-note (Xu 2026), Appendix A.5.
+test_that("gsynth() EM + parametric inference now errors (v1.5.0 hard gate)", {
   skip_on_cran()
-  expect_warning(
-    out <- gsynth(Y ~ D + X1 + X2, data = simdata,
-                  index = c("id", "time"), EM = TRUE, se = TRUE,
-                  inference = "parametric", nboots = 50, r = 2,
-                  parallel = FALSE),
-    "nonparametric bootstrap"
+  expect_error(
+    suppressPackageStartupMessages(
+      gsynth(Y ~ D + X1 + X2, data = simdata,
+             index = c("id", "time"), EM = TRUE, se = TRUE,
+             inference = "parametric", nboots = 50, r = 2,
+             parallel = FALSE)
+    )
   )
-  expect_equal(out$vartype, "bootstrap")
 })
 
 test_that("gsynth() nonparametric inference is remapped", {
@@ -174,4 +181,49 @@ test_that("gsynth() normalize = TRUE works", {
                 normalize = TRUE, parallel = FALSE)
 
   expect_s3_class(out, "gsynth")
+})
+
+# --- v1.5.0 new pass-through args ---
+
+test_that("gsynth() accepts cv.method = 'rolling' (default in v1.5.0)", {
+  skip_on_cran()
+  out <- gsynth(Y ~ D + X1 + X2, data = simdata,
+                index = c("id", "time"), CV = TRUE, r = c(0, 3),
+                cv.method = "rolling", cv.prop = 0.1, k = 20,
+                se = FALSE, parallel = FALSE)
+
+  expect_s3_class(out, "gsynth")
+  expect_false(is.null(out$r.cv))
+})
+
+test_that("gsynth() accepts cv.method = 'block' (pre-v1.5 reproduction)", {
+  skip_on_cran()
+  out <- gsynth(Y ~ D + X1 + X2, data = simdata,
+                index = c("id", "time"), CV = TRUE, r = c(0, 3),
+                cv.method = "block", k = 5,
+                se = FALSE, parallel = FALSE)
+
+  expect_s3_class(out, "gsynth")
+  expect_false(is.null(out$r.cv))
+})
+
+test_that("gsynth() accepts cv.buffer", {
+  skip_on_cran()
+  out <- gsynth(Y ~ D + X1 + X2, data = simdata,
+                index = c("id", "time"), CV = TRUE, r = c(0, 3),
+                cv.method = "rolling", cv.buffer = 2,
+                se = FALSE, parallel = FALSE)
+
+  expect_s3_class(out, "gsynth")
+})
+
+test_that("gsynth() accepts time.component.from = 'nevertreated'", {
+  skip_on_cran()
+  out <- gsynth(Y ~ D + X1 + X2, data = simdata,
+                index = c("id", "time"),
+                time.component.from = "nevertreated",
+                se = FALSE, r = 2, parallel = FALSE)
+
+  expect_s3_class(out, "gsynth")
+  expect_equal(out$method, "gsynth")
 })

--- a/tests/testthat/test-hard-gate.R
+++ b/tests/testthat/test-hard-gate.R
@@ -1,0 +1,76 @@
+# Tests for the v1.5.0 hard-gate alignment with fect v2.2.0+ and
+# the public commitment in Xu (2026), "A Response to Green and Aronow,"
+# Appendix A.5: inference = "parametric" combined with IFE-EM or MC
+# now errors instead of silently coercing to bootstrap.
+
+data(simdata, package = "gsynth")
+
+test_that("inference = 'parametric' + estimator = 'ife' errors", {
+  skip_on_cran()
+  expect_error(
+    suppressPackageStartupMessages(
+      gsynth(Y ~ D + X1 + X2, data = simdata,
+             index = c("id", "time"), estimator = "ife",
+             inference = "parametric", se = TRUE, nboots = 50,
+             r = 2, parallel = FALSE)
+    )
+  )
+})
+
+test_that("inference = 'parametric' + estimator = 'mc' errors", {
+  skip_on_cran()
+  expect_error(
+    suppressPackageStartupMessages(
+      gsynth(Y ~ D + X1 + X2, data = simdata,
+             index = c("id", "time"), estimator = "mc",
+             inference = "parametric", se = TRUE, nboots = 50,
+             parallel = FALSE)
+    )
+  )
+})
+
+test_that("inference = 'parametric' + EM = TRUE errors", {
+  skip_on_cran()
+  expect_error(
+    suppressPackageStartupMessages(
+      gsynth(Y ~ D + X1 + X2, data = simdata,
+             index = c("id", "time"), EM = TRUE,
+             inference = "parametric", se = TRUE, nboots = 50,
+             r = 2, parallel = FALSE)
+    )
+  )
+})
+
+test_that("inference = 'bootstrap' with IFE-EM works (no hard gate)", {
+  skip_on_cran()
+  out <- suppressPackageStartupMessages(
+    gsynth(Y ~ D + X1 + X2, data = simdata,
+           index = c("id", "time"), estimator = "ife",
+           inference = "bootstrap", se = TRUE, nboots = 50,
+           r = 2, parallel = FALSE)
+  )
+  expect_s3_class(out, "gsynth")
+  expect_equal(out$vartype, "bootstrap")
+})
+
+test_that("inference = 'jackknife' with IFE-EM works (no hard gate)", {
+  skip_on_cran()
+  out <- suppressPackageStartupMessages(
+    gsynth(Y ~ D + X1 + X2, data = simdata,
+           index = c("id", "time"), estimator = "ife",
+           inference = "jackknife", se = TRUE,
+           r = 2, parallel = FALSE)
+  )
+  expect_s3_class(out, "gsynth")
+  expect_equal(out$vartype, "jackknife")
+})
+
+test_that("inference = 'parametric' with GSC (default) works", {
+  skip_on_cran()
+  out <- gsynth(Y ~ D + X1 + X2, data = simdata,
+                index = c("id", "time"), estimator = "gsynth",
+                inference = "parametric", se = TRUE, nboots = 50,
+                r = 2, parallel = FALSE)
+  expect_s3_class(out, "gsynth")
+  expect_equal(out$vartype, "parametric")
+})

--- a/tests/testthat/test-placebo.R
+++ b/tests/testthat/test-placebo.R
@@ -1,0 +1,91 @@
+# Tests for the v1.5.0 placeboTest argument on gsynth()
+# (forwards fect's placebo machinery). gsynth does not expose
+# carryoverTest because gsynth does not allow treatment reversals,
+# which fect's carryover test requires.
+
+data(simdata, package = "gsynth")
+
+test_that("placeboTest = TRUE produces placebo slots on the fit", {
+  skip_on_cran()
+  out <- gsynth(Y ~ D + X1 + X2, data = simdata,
+                index = c("id", "time"), force = "two-way",
+                CV = FALSE, r = 2, se = TRUE,
+                inference = "bootstrap", nboots = 50,
+                placeboTest = TRUE, placebo.period = c(-2, 0),
+                parallel = FALSE)
+  expect_true(isTRUE(out$placeboTest))
+  expect_false(is.null(out$est.placebo))
+  expect_false(is.null(out$att.placebo))
+})
+
+test_that("placeboTest = FALSE leaves placebo slots empty", {
+  skip_on_cran()
+  out <- gsynth(Y ~ D + X1 + X2, data = simdata,
+                index = c("id", "time"), force = "two-way",
+                CV = FALSE, r = 2, se = TRUE,
+                inference = "bootstrap", nboots = 50,
+                parallel = FALSE)
+  expect_false(isTRUE(out$placeboTest))
+})
+
+test_that("placebo.period defaults to NULL when placeboTest = FALSE", {
+  skip_on_cran()
+  ## Just verifying no error fires when only one of the two args is set.
+  out <- gsynth(Y ~ D + X1 + X2, data = simdata,
+                index = c("id", "time"), force = "two-way",
+                CV = FALSE, r = 2, se = FALSE,
+                placebo.period = c(-2, 0),
+                parallel = FALSE)
+  expect_s3_class(out, "gsynth")
+})
+
+test_that("placebo.period accepts a length-1 integer", {
+  skip_on_cran()
+  out <- gsynth(Y ~ D + X1 + X2, data = simdata,
+                index = c("id", "time"), force = "two-way",
+                CV = FALSE, r = 2, se = TRUE,
+                inference = "bootstrap", nboots = 50,
+                placeboTest = TRUE, placebo.period = -2,
+                parallel = FALSE)
+  expect_true(isTRUE(out$placeboTest))
+})
+
+test_that("carryoverTest is not exposed on gsynth()", {
+  skip_on_cran()
+  ## gsynth() does not accept carryoverTest in its formals (gsynth requires
+  ## staggered no-reversal panels; carryover test requires reversals).
+  fmls <- names(formals(gsynth))
+  expect_false("carryoverTest" %in% fmls)
+  expect_false("carryover.period" %in% fmls)
+})
+
+test_that("placeboTest is forwarded only when explicitly TRUE", {
+  skip_on_cran()
+  ## Default fit (placeboTest = FALSE) and explicit FALSE produce
+  ## numerically identical fits.
+  set.seed(42)
+  out_default <- gsynth(Y ~ D + X1 + X2, data = simdata,
+                        index = c("id", "time"), force = "two-way",
+                        CV = FALSE, r = 2, se = FALSE,
+                        parallel = FALSE)
+  set.seed(42)
+  out_explicit <- gsynth(Y ~ D + X1 + X2, data = simdata,
+                         index = c("id", "time"), force = "two-way",
+                         CV = FALSE, r = 2, se = FALSE,
+                         placeboTest = FALSE,
+                         parallel = FALSE)
+  expect_equal(out_default$att, out_explicit$att)
+})
+
+test_that("placebo fit populates est.placebo with point/SE/CI columns", {
+  skip_on_cran()
+  out <- gsynth(Y ~ D + X1 + X2, data = simdata,
+                index = c("id", "time"), force = "two-way",
+                CV = FALSE, r = 2, se = TRUE,
+                inference = "bootstrap", nboots = 50,
+                placeboTest = TRUE, placebo.period = c(-2, 0),
+                parallel = FALSE)
+  expect_false(is.null(out$est.placebo))
+  expect_true(any(grepl("ATT|p.value|S.E.|CI",
+                        colnames(as.matrix(out$est.placebo)))))
+})

--- a/tests/testthat/test-plot-modern-theme.R
+++ b/tests/testthat/test-plot-modern-theme.R
@@ -1,0 +1,58 @@
+# Smoke tests for v1.5.0 modern-theme pass-through args on plot.gsynth():
+# legacy.style, highlight, highlight.fill. Also verifies that
+# type = "loading.overlap" routes through to fect cleanly.
+
+data(simdata, package = "gsynth")
+
+test_that("plot(out, type = 'gap', legacy.style = TRUE) returns a plot", {
+  skip_on_cran()
+  out <- gsynth(Y ~ D + X1 + X2, data = simdata,
+                index = c("id", "time"), se = FALSE, r = 2,
+                parallel = FALSE)
+  p <- plot(out, type = "gap", legacy.style = TRUE)
+  expect_true(inherits(p, "ggplot") || inherits(p, "gtable") ||
+              is.list(p))
+})
+
+test_that("plot(out, type = 'gap', legacy.style = FALSE) returns a plot", {
+  skip_on_cran()
+  out <- gsynth(Y ~ D + X1 + X2, data = simdata,
+                index = c("id", "time"), se = FALSE, r = 2,
+                parallel = FALSE)
+  p <- plot(out, type = "gap", legacy.style = FALSE)
+  expect_true(inherits(p, "ggplot") || inherits(p, "gtable") ||
+              is.list(p))
+})
+
+test_that("plot(out, type = 'loading.overlap') runs without error", {
+  skip_on_cran()
+  out <- gsynth(Y ~ D + X1 + X2, data = simdata,
+                index = c("id", "time"), se = FALSE, r = 2,
+                parallel = FALSE)
+  expect_error(
+    plot(out, type = "loading.overlap"),
+    NA  # expect no error
+  )
+})
+
+test_that("plot(out, highlight = NULL, highlight.fill = FALSE) is the default path", {
+  skip_on_cran()
+  out <- gsynth(Y ~ D + X1 + X2, data = simdata,
+                index = c("id", "time"), se = FALSE, r = 2,
+                parallel = FALSE)
+  p <- plot(out, type = "gap",
+            highlight = NULL, highlight.fill = FALSE)
+  expect_true(inherits(p, "ggplot") || inherits(p, "gtable") ||
+              is.list(p))
+})
+
+test_that("plot(out, highlight.fill = TRUE) runs without error", {
+  skip_on_cran()
+  out <- gsynth(Y ~ D + X1 + X2, data = simdata,
+                index = c("id", "time"), se = FALSE, r = 2,
+                parallel = FALSE)
+  expect_error(
+    plot(out, type = "gap", highlight.fill = TRUE),
+    NA
+  )
+})

--- a/tests/testthat/test-soft-deprecation.R
+++ b/tests/testthat/test-soft-deprecation.R
@@ -1,0 +1,102 @@
+# Tests for v1.5.0 soft-deprecation messages on IFE-EM, MC, EM = TRUE,
+# and effect(). Each message fires once per session via the
+# .gsynth_deprecation_seen closure in R/default.R.
+
+data(simdata, package = "gsynth")
+
+# Helper: peel into the package internals to reset the deprecation cache,
+# so each test starts from a clean slate. Tests run in the package's own
+# environment, so we can access the closure directly.
+.reset_deprecation_seen <- function() {
+  env <- environment(gsynth:::.gsynth_deprecation_seen)
+  env$seen <- character(0)
+  invisible(NULL)
+}
+
+test_that("estimator = 'ife' emits a deprecation message", {
+  skip_on_cran()
+  .reset_deprecation_seen()
+  msg <- capture.output(
+    out <- gsynth(Y ~ D + X1 + X2, data = simdata,
+                  index = c("id", "time"), estimator = "ife",
+                  se = FALSE, r = 2, parallel = FALSE),
+    type = "message"
+  )
+  expect_match(paste(msg, collapse = "\n"),
+               "soft-deprecated", fixed = FALSE)
+  expect_match(paste(msg, collapse = "\n"),
+               "fect::fect", fixed = TRUE)
+  expect_s3_class(out, "gsynth")
+})
+
+test_that("estimator = 'mc' emits a deprecation message", {
+  skip_on_cran()
+  .reset_deprecation_seen()
+  msg <- capture.output(
+    out <- gsynth(Y ~ D + X1 + X2, data = simdata,
+                  index = c("id", "time"), estimator = "mc",
+                  se = FALSE, parallel = FALSE),
+    type = "message"
+  )
+  expect_match(paste(msg, collapse = "\n"),
+               "soft-deprecated", fixed = FALSE)
+  expect_match(paste(msg, collapse = "\n"),
+               "fect::fect", fixed = TRUE)
+  expect_s3_class(out, "gsynth")
+})
+
+test_that("EM = TRUE emits a deprecation message", {
+  skip_on_cran()
+  .reset_deprecation_seen()
+  msg <- capture.output(
+    out <- gsynth(Y ~ D + X1 + X2, data = simdata,
+                  index = c("id", "time"), EM = TRUE,
+                  se = FALSE, r = 2, parallel = FALSE),
+    type = "message"
+  )
+  combined <- paste(msg, collapse = "\n")
+  expect_match(combined, "soft-deprecated", fixed = FALSE)
+  expect_match(combined, "fect::fect", fixed = TRUE)
+  expect_s3_class(out, "gsynth")
+})
+
+test_that("deprecation message fires only once per session per key", {
+  skip_on_cran()
+  .reset_deprecation_seen()
+
+  ## First call: message expected
+  msg1 <- capture.output(
+    gsynth(Y ~ D + X1 + X2, data = simdata,
+           index = c("id", "time"), estimator = "ife",
+           se = FALSE, r = 2, parallel = FALSE),
+    type = "message"
+  )
+  ## Second call: message should NOT fire again
+  msg2 <- capture.output(
+    gsynth(Y ~ D + X1 + X2, data = simdata,
+           index = c("id", "time"), estimator = "ife",
+           se = FALSE, r = 2, parallel = FALSE),
+    type = "message"
+  )
+
+  expect_true(any(grepl("soft-deprecated", msg1)))
+  expect_false(any(grepl("soft-deprecated", msg2)))
+})
+
+test_that("effect() emits a deprecation message pointing to estimand()", {
+  skip_on_cran()
+  .reset_deprecation_seen()
+
+  ## fect::effect() requires bootstrap/jackknife results; fit with se = TRUE.
+  out <- gsynth(Y ~ D + X1 + X2, data = simdata,
+                index = c("id", "time"), se = TRUE, nboots = 50, r = 2,
+                parallel = FALSE)
+
+  msg <- capture.output(
+    cumu <- effect(out, cumu = TRUE, plot = FALSE),
+    type = "message"
+  )
+  combined <- paste(msg, collapse = "\n")
+  expect_match(combined, "soft-deprecated", fixed = FALSE)
+  expect_match(combined, "estimand", fixed = TRUE)
+})

--- a/tutorial/01-gsynth.Rmd
+++ b/tutorial/01-gsynth.Rmd
@@ -5,7 +5,20 @@ knitr::opts_chunk$set(echo = TRUE, message = FALSE, warning = FALSE,
                       fig.width = 10, fig.height = 7)
 ```
 
-This chapter demonstrates the default **gsynth** estimator (`estimator = "gsynth"`, [@Xu2017]), which estimates latent factors from the control group only and then imputes counterfactuals for treated units. We cover three settings: block DID, staggered DID, and unbalanced panels.
+This chapter demonstrates the default **gsynth** estimator---`estimator = "gsynth"`, [@Xu2017]--- which estimates latent factors from the control group only and then imputes counterfactuals for treated units. We cover three settings: block DID, staggered DID, and unbalanced panels, with a dedicated section on inference and one on the placebo test.
+
+For plot customization, see [Chapter @sec-plots]. For IFE-EM and matrix completion (the soft-deprecated paths), see [Chapter @sec-ife-mc].
+
+::: {.callout-important}
+## Conduct diagnostics
+
+GSC imputes treated counterfactuals by projecting treated-unit loadings onto a factor space estimated from controls. The estimator can return tight-looking confidence intervals even when (a) the treated loadings sit outside the convex hull of control loadings, so the imputation is an extrapolation, or (b) the model overfits, and the parallel-trends-on-factors assumption fails. A point estimate plus a CI is not enough. Two checks should accompany every gsynth fit:
+
+- **Loading-overlap** (`plot(out, type = "loading.overlap")`): are treated points inside the shaded control hull? Outside-hull treated units flag extrapolation; report results with that caveat or drop those units.
+- **Placebo test** (`placeboTest = TRUE, placebo.period = c(...)`): does the model recover near-zero effects on held-out pre-treatment periods? A rejected placebo is evidence against the valid assumptions, and the headline ATT should not be read at face value.
+
+Both diagnostics are demonstrated below for the simulated data and again for the staggered turnout application.
+:::
 
 ```{r}
 library(gsynth)
@@ -26,37 +39,32 @@ head(simdata)
 Before estimation, visualize the data structure with **panelView**.
 
 ```{r simdata-panelview-raw, fig.height = 10}
-panelview(Y ~ D, data = simdata, index = c("id", "time"), 
+panelview(Y ~ D, data = simdata, index = c("id", "time"),
           pre.post = TRUE)
 ```
 
 Outcome trajectories by treatment status:
 
 ```{r simdata-panelview-outcome}
-panelview(Y ~ D, data = simdata, index = c("id", "time"), 
+panelview(Y ~ D, data = simdata, index = c("id", "time"),
           type = "outcome")
 ```
 
-### Estimation & Inference
+### Estimation
 
 We estimate the model using the outcome $Y$, the treatment indicator $D$, and two covariates $X_1$ and $X_2$.
 
-The `force` option specifies fixed effects: `"none"`, `"unit"`, `"time"`, or `"two-way"`. Cross-validation (`CV = TRUE`) selects the number of factors within the range specified by `c(0, 5)`.
+The `force` option specifies fixed effects: `"none"`, `"unit"`, `"time"`, or `"two-way"`. Cross-validation (`CV = TRUE`) selects the number of factors within the range specified by `c(0, 5)`. From v1.5.0 the CV default is rolling-window with `k = 20` folds, `cv.prop = 0.1`, `cv.buffer = 1`. To reproduce the pre-v1.5.0 block-CV behavior in existing code, set `cv.method = "block"` and `k = 5` explicitly.
 
-For finite sample inference, set `se = TRUE`. With few treated units, use `inference = "parametric"`. 
 ```{r sim1, cache = TRUE}
-system.time(
-    out <- gsynth(Y ~ D + X1 + X2, data = simdata,
-                  index = c("id", "time"), force = "two-way",
-                  CV = TRUE, r = c(0, 5), se = TRUE,
-                  inference = "parametric", nboots = 1000,
-                  parallel = FALSE)
-)
+out <- gsynth(Y ~ D + X1 + X2, data = simdata,
+              index = c("id", "time"), force = "two-way",
+              CV = TRUE, r = c(0, 5), se = TRUE,
+              inference = "parametric", nboots = 1000,
+              parallel = TRUE, cores = 16)
 ```
 
-For super-population inferences (with a large $N$, and $N_{tr}$ grows with $N$), users can also use `inference = "nonparametric"` or `inference = "jackknife"`.
-
-The output shows: `sigma2` (error variance), `IC` (information criterion), and `MSPE` (mean squared prediction error). Cross-validation selects the $r$ that minimizes MSPE.
+The output reports `sigma2` (error variance), `IC` (information criterion), and `MSPE` (mean squared prediction error). Cross-validation selects the `r` that minimizes MSPE.
 
 ```{r}
 out$est.att
@@ -64,119 +72,137 @@ out$est.avg
 out$est.beta
 ```
 
-### Parallel computing
-
-Parallel computing (`parallel = TRUE`) speeds up the bootstrap procedure. We recommend that users manually set the number of cores using the `cores` option. If this is not supplied or is `NULL`, we will automatically select the smaller of `8` and the number of usable system cores minus `2`, to prevent excessive use of system resources.
-
-```{r sim2, cache = TRUE}
-system.time(
-out <- gsynth(Y ~ D + X1 + X2, data = simdata,
-              index = c("id", "time"), force = "two-way",
-              CV = TRUE, r = c(0, 5), se = TRUE,
-              inference = "parametric", nboots = 1000,
-              parallel = TRUE, cores = 10)
-)
-print(out)
-```
-
-
-### Cumulative effects
-
-The `effect` function calculates cumulative treatment effects. Specify a period of interest with `period`; if omitted, all post-treatment periods are used.
-
-```{r cumu1, cache = TRUE}
-cumu1 <- effect(out, cumu = TRUE, id = NULL)
-cumu1$effect.est.att
-plot(cumu1)
-```
-
-Sub-group effects and average (non-cumulative) effects:
-
-```{r cumu2, cache = TRUE}
-cumu2 <- effect(out, cumu = FALSE, id = c(101, 102, 103), 
-                period = c(1, 5))
-cumu2$effect.est.att
-plot(cumu2)
-```
-
 ### Plot results
 
-The default `plot` produces a "gap" plot showing the estimated ATT by period. The true effects in `simdata` go from 1 to 10 (plus noise) from period 21 to 30.
+The default `plot()` produces a "gap" plot showing the estimated ATT by period. The true effects in `simdata` go from 1 to 10 (plus noise) from period 21 to 30.
 
-```{r sim-gap1}
+```{r sim-gap}
 plot(out)
 ```
 
-A default *ggplot2* theme:
+For counterfactual plots, factor / loading plots, and customization (axes, legends, modern vs legacy visual recipe, highlight API), see [Chapter @sec-plots].
 
-```{r sim-gap1a}
-plot(out, theme.bw = FALSE)
+### Factors and loadings
+
+We fit with two factors (`r=2`) to inspect the estimated factor structure directly:
+
+```{r r2-fit, cache = TRUE}
+out_r2 <- gsynth(Y ~ D + X1 + X2, data = simdata,
+                 index = c("id", "time"), force = "two-way",
+                 r = 2, CV = FALSE, se = FALSE,
+                 parallel = FALSE)
 ```
 
-Customize axes and title:
-
-```{r sim-gap2}
-plot(out, type = "gap", ylim = c(-10, 12), xlab = "Period",
-     main = "My GSynth Plot")
-```
-
-#### Raw data
-
-```{r sim-raw1}
-plot(out, type = "raw")
-```
-
-#### Counterfactuals
-
-```{r ct1}
-plot(out, type = "counterfactual", raw = "none", main = "")
-```
-
-Without post-treatment shading:
-
-```{r ct1a}
-plot(out, type = "ct", raw = "none", main = "",
-     shade.post = FALSE)
-```
-
-With quantile bands (5th--95th percentile):
-
-```{r ct2}
-plot(out, type = "counterfactual", raw = "band",
-     xlab = "Time", ylim = c(-5, 35))
-```
-
-With all raw data:
-
-```{r ct3}
-plot(out, type = "counterfactual", raw = "all")
-```
-
-Unit-level counterfactuals:
-
-```{r ct4}
-plot(out, type = "counterfactual", id = 102)
-```
-
-```{r ct5}
-plot(out, type = "counterfactual", id = 104,
-     raw = "band", ylim = c(-10, 30))
-```
-
-```{r ct6}
-plot(out, type = "counterfactual", id = 105,
-     raw = "all", legendOff = TRUE)
-```
-
-#### Factors and loadings
+`type = "factors"` plots the estimated time-varying factors (one curve per factor), and `type = "loadings"` shows the distribution of unit-level loadings on each factor:
 
 ```{r sim-factors, results='hide'}
-plot(out, type = "factors", xlab = "Time")
+plot(out_r2, type = "factors", xlab = "Time")
 ```
 
 ```{r sim-loadings, fig.height = 5, results='hide'}
-plot(out, type = "loadings")
+plot(out_r2, type = "loadings")
 ```
+
+### Loading-overlap diagnostic
+
+The generalized synthetic control method imputes each treated unit's counterfactual by projecting its loadings onto a factor space estimated from controls. When the treated-unit loadings sit *outside* the convex hull of control-unit loadings, the imputed counterfactual is an extrapolation rather than a weighted combination of observed control trajectories.
+
+`plot(out, type = "loading.overlap")` shows treated and control loadings in the first two factor dimensions, with the convex hull of control loadings shaded. Use it as an at-fit diagnostic, paired with the placebo test below.
+
+```{r sim-loading-overlap, fig.height = 5, results='hide'}
+plot(out_r2, type = "loading.overlap")
+```
+
+When all treated points fall inside the shaded control hull, the GSC counterfactual is supported by interpolation across observed control trajectories. When treated points fall outside the hull, the counterfactual extrapolates beyond the observed support, and the placebo test below should be checked carefully.
+
+## Inference
+
+`gsynth()` supports three inference methods via the `inference` argument; the default depends on the estimator:
+
+| `inference =` | Method | When to use | Default for |
+| --- | --- | --- | --- |
+| `"parametric"` | Parametric bootstrap with AR-aware residual draws (@Xu2017; AR-preserving fix in **fect** v2.3.0) | Small $N_{tr}$; finite-sample setting | `estimator = "gsynth"` |
+| `"bootstrap"` (alias `"nonparametric"`) | Block bootstrap at unit level (or cluster level if `cl` set) | Large $N$, $N_{tr}$ growing with $N$; super-population framework | `estimator = "ife"` and `"mc"` |
+| `"jackknife"` | Leave-one-unit-out jackknife | Cluster-robust under leave-one-unit-out resampling; computationally cheap when $N_{co}$ is moderate | --- |
+
+### Confidence-interval method (`ci.method`)
+
+New in v1.5.0. The `ci.method` argument controls how the confidence intervals stored in the `est.*` slots (e.g. `out$est.att`) are formed:
+
+- `ci.method = "normal"` (default): Wald intervals, $\hat{\theta} \pm z_{1-\alpha/2}\,\widehat{\mathrm{SE}}$. Symmetric around the point estimate.
+- `ci.method = "basic"`: reflected-pivot bootstrap interval (@DavisonHinkley1997, Sec. 5.2.1). Asymmetric; reads tail quantiles of the bootstrap distribution. Requires `inference = "bootstrap"` or `"jackknife"`. With $B < 1000$ replications the tail-quantile endpoints can be unstable; **fect** emits a warning and recommends `nboots = 1000` for publication-grade CIs.
+
+For percentile, BC, and BCa intervals on the alternative estimands (`att.cumu`, `aptt`, `log.att`), call `estimand(fit, type, ci.method = ...)` post-fit.
+
+### Number of bootstrap replicates (`nboots`)
+
+The default is `nboots = 200`, sufficient for SEs and Wald (`"normal"`) CIs. For tail-quantile-based intervals (`ci.method = "basic"`, `"percentile"`, `"bc"`, `"bca"`), bump to `nboots = 1000+`.
+
+### Parallel computing
+
+`parallel = TRUE` (default) speeds up both the bootstrap and the cross-validation. Set `cores` explicitly when running on a shared machine; if `cores = NULL`, `gsynth` selects `min(8, parallel::detectCores() - 2)`.
+
+```{r sim2, cache = TRUE}
+out_fast <- gsynth(Y ~ D + X1 + X2, data = simdata,
+                   index = c("id", "time"), force = "two-way",
+                   CV = TRUE, r = c(0, 5), se = TRUE,
+                   inference = "parametric", nboots = 1000,
+                   parallel = TRUE, cores = 16)
+print(out_fast)
+```
+
+### Comparing CI methods on the same fit
+
+```{r ci-method-compare, cache = TRUE}
+out_basic <- gsynth(Y ~ D + X1 + X2, data = simdata,
+                    index = c("id", "time"), force = "two-way",
+                    CV = TRUE, r = c(0, 5), se = TRUE,
+                    inference = "bootstrap", nboots = 1000,
+                    ci.method = "basic",
+                    parallel = TRUE, cores = 16)
+head(out_basic$est.att)
+```
+
+The point estimate and SE are identical to a `ci.method = "normal"` fit on the same bootstrap replicates; only the CI columns differ. Asymmetry of the basic interval relative to the Wald interval signals skewness in the bootstrap distribution.
+
+## Placebo test {#sec-placebo}
+
+A placebo test re-fits the model after pretending some pre-treatment periods are part of the treated window, then asks whether the estimated effect on those held-out periods is close to zero. If the model is well-specified and the parallel-trends assumption holds, the placebo effect should be near zero. If it is not, the headline ATT estimate is suspect.
+
+In v1.5.0, `gsynth()` accepts two new arguments for this:
+
+- `placeboTest = TRUE` --- turn the placebo test on.
+- `placebo.period = c(start, end)` --- which event-time periods to use as the placebo block. For example, `c(-2, 0)` treats event-times $-2$ through $0$ as placebo.
+
+The default `plot()` highlights the placebo region automatically when `placeboTest = TRUE` was set at fit time.
+
+```{r placebo-intro, cache = TRUE}
+out_pb <- gsynth(Y ~ D + X1 + X2, data = simdata,
+                 index = c("id", "time"), force = "two-way",
+                 r = 2, CV = FALSE, se = TRUE,
+                 inference = "bootstrap", nboots = 500,
+                 placeboTest = TRUE, placebo.period = c(-2, 0),
+                 parallel = TRUE, cores = 16)
+```
+
+```{r placebo-intro-plot}
+plot(out_pb, main = "Placebo test on simdata")
+```
+
+The plot has two regions worth checking:
+
+- **Pre-placebo (event time $< -2$):** the estimated effect should fluctuate around zero. Persistent deviation here means the model is fitting noise as signal, not an overlap problem.
+- **Placebo region (event times $-2$ through $0$):** the confidence interval should cover zero. If it does, the test fails to reject pre-treatment zero, which is consistent with the parallel-trends assumption.
+
+For numeric output by event time, the slot `out_pb$est.placebo` holds the placebo-region inference (point estimate, SE, CI), and `out_pb$est.att` holds the ATT estimates outside the placebo block.
+
+```{r placebo-intro-table}
+out_pb$est.placebo
+```
+
+A note on language: a placebo test that *fails to reject* pre-treatment zero is consistent with the assumption; it does not prove the assumption holds. Conversely, a placebo test that *rejects* pre-treatment zero is evidence against the model's pre-treatment fit, and the post-treatment ATT should then be reported with that caveat.
+
+The placebo test comes back in [Chapter @sec-ife-mc] applied to the IFE-EM and matrix-completion estimators.
 
 ## Staggered DID
 
@@ -235,7 +261,7 @@ out <- gsynth(turnout ~ policy_edr + policy_mail_in + policy_motor,
 
 ### Implied weights
 
-`out$wgt.implied` ($N_{co} \times N_{tr}$) stores the implied weights of all control units for each treated unit. Unlike synthetic control, the weights can be both positive and negative.
+`out$wgt.implied` (`N_co × N_tr`) stores the implied weights of all control units for each treated unit. Unlike classical synthetic control, the weights can be both positive and negative.
 
 ```{r}
 dim(out$wgt.implied)
@@ -243,8 +269,6 @@ sort(out$wgt.implied[, 8])
 ```
 
 ### Plot results
-
-Gap plot:
 
 ```{r turnout-gap}
 plot(out, type = "gap", xlim = c(-10, 5), ylim = c(-15, 15))
@@ -256,36 +280,9 @@ State-specific gap (Wisconsin):
 plot(out, type = "gap", id = "WI", main = "Wisconsin")
 ```
 
-Raw turnout data:
+### Factors and loadings
 
-```{r turnout-raw}
-plot(out, type = "raw", xlab = "Year", ylab = "Turnout")
-```
-
-Estimated average counterfactual (realigned by treatment timing):
-
-```{r turnout-ct}
-plot(out, type = "counterfactual", raw = "all")
-```
-
-Unit-level counterfactuals:
-
-```{r turnout-ct1}
-plot(out, type = "counterfactual", id = "CT")
-```
-
-```{r turnout-ct2}
-plot(out, type = "counterfactual", id = "WY",
-     raw = "all", legendOff = TRUE)
-```
-
-```{r turnout-ct3}
-plot(out, type = "counterfactual", id = "WI",
-     raw = "none", shade.post = FALSE, ylim = c(0, 100),
-     legend.labs = c("Wisconsin Actual", "Wisconsin Counterfactual"))
-```
-
-Estimated factors and loadings:
+The estimated time-varying factors and unit-level loadings:
 
 ```{r turnout-factors, results='hide'}
 plot(out, type = "factors", xlab = "Year")
@@ -295,6 +292,14 @@ plot(out, type = "factors", xlab = "Year")
 plot(out, type = "loadings")
 ```
 
+Loading-overlap check on the turnout fit, in the first two factor dimensions:
+
+```{r turnout-loading-overlap, fig.height = 5, results='hide'}
+plot(out, type = "loading.overlap")
+```
+
+Additional plot types and customization (raw, counterfactual, modern theme, highlight API) are in [Chapter @sec-plots].
+
 ## Unbalanced panels
 
 **gsynth** can accommodate unbalanced panels. We demonstrate by randomly removing observations from the `turnout` dataset.
@@ -302,7 +307,7 @@ plot(out, type = "loadings")
 ```{r}
 set.seed(123456)
 turnout.ub <- turnout[-c(which(turnout$abb == "WY")[1:15],
-                         sample(1:nrow(turnout), 50, 
+                         sample(1:nrow(turnout), 50,
                                 replace = FALSE)), ]
 ```
 
@@ -325,9 +330,11 @@ out <- gsynth(turnout ~ policy_edr + policy_mail_in + policy_motor,
               nboots = 1000, seed = 02139)
 ```
 
-### Plot results
+On unbalanced panels, the parametric bootstrap uses a unit-level Gaussian approximation for residual perturbations (introduced in **fect** v2.3.0); residuals are drawn from a Gaussian fitted to each unit's residual structure rather than from the empirical pool, naturally accommodating missing cells. This is automatic — no API change for the user. Balanced panels see no change in behavior.
 
-The `"missing"` plot shows the data used in estimation. Gray cells with red dots indicate observations removed due to insufficient pre-treatment periods. The matrix is available in `out$obs.missing`, where 0 = missing, 1 = control, 2 = treated (pre), 3 = treated (post), 4 = treated (removed).
+### Missing-data plot
+
+The `"missing"` plot shows the data used in estimation. Gray cells with red dots indicate observations removed due to insufficient pre-treatment periods. The matrix is available in `out$obs.missing` (`0` = missing, `1` = control, `2` = treated pre, `3` = treated post, `4` = treated removed).
 
 ```{r turnout-ub-missing, fig.height = 10}
 plot(out, type = "missing")
@@ -350,7 +357,5 @@ plot(out, type = "gap", xlim = c(-10, 5), ylim = c(-15, 15))
 ### Notes on performance
 
 1. Unbalanced panels take significantly more time than balanced panels (often 100:1 or higher) due to the EM algorithm for missing values.
-
 2. Adding covariates also slows the algorithm because the IFE/MC model takes more iterations to converge.
-
-3. Setting `min.T0` to a positive number helps --- the algorithm discards treated units with too few pre-treatment periods. A larger $T_0$ reduces bias and extrapolation risk. For cross-validation, `min.T0` must be at least `r.max + 2`.
+3. Setting `min.T0` to a positive number helps — the algorithm discards treated units with too few pre-treatment periods. A larger `T_0` reduces bias and extrapolation risk. For cross-validation, `min.T0` must be at least `r.max + 2`.

--- a/tutorial/02-ife-mc.Rmd
+++ b/tutorial/02-ife-mc.Rmd
@@ -5,41 +5,25 @@ knitr::opts_chunk$set(echo = TRUE, message = FALSE, warning = FALSE,
                       fig.width = 10, fig.height = 7)
 ```
 
-In the difference-in-differences setting (with a large $N$, and $N_{tr}$ grows with $N$), @Gobillon2016 propose an EM algorithm that exploits pre-treatment observations from treated units, while @Athey2021 propose a matrix completion approach that imputes counterfactual outcomes under a low-rank structure. Both methods use information from never-treated controls and not-yet-treated observations of treated units, and conduct inference under a super-population framework.
+::: {.callout-warning}
 
-For a comparison with Gsynth, see the discussion in the **fect** [User Manual](https://yiqingxu.org/packages/fect/index.html).
+## Soft-deprecated in v1.5.0
 
-## Breaking change in v1.4.0 {#sec-breaking}
+`estimator = "ife"` (IFE-EM, @Gobillon2016), `estimator = "mc"` (matrix completion, @Athey2021), and the legacy `EM = TRUE` flag are soft-deprecated in `gsynth` v1.5.0 and will be **removed in v2.0.0** (target: late 2026).
 
-We realize the `EM` option has caused confusion. In fact, when there are missing data in the control group, Gsynth will automatically use the EM algorithm to fill the missing data. The key difference is that the factors are learned from the control units only, not from pre-treatment observations of the treated units.
+Each call to one of these paths emits a one-time-per-session console message. Behavior is unchanged from v1.4.0 --- the deprecation is a signal, not a break.
 
-In early versions, when the estimator is not specified, `EM = TRUE` activates the Gobillon-Magnac IFE-EM estimator, which has implications for what inferential method is feasible. For example, `inference = "parametric"` is not suitable for the IFE-EM and MC estimators given they are super-population based. 
+For new code, use [`fect::fect()`](https://yiqingxu.org/packages/fect/) directly. The **gsynth** package is built around the GSC estimator (@Xu2017); IFE-EM and matrix completion are now documented and maintained in **fect**. Migration recipes are in @sec-migration below.
 
-To avoid this confusion, starting from v1.4.0, the `estimator` parameter maps directly to the estimation method.
+:::
 
-**What changed from v1.3.x:**
+In the difference-in-differences setting (with a large $N$, and $N_{tr}$ growing with $N$), @Gobillon2016 propose an EM algorithm that exploits pre-treatment observations from treated units; @Athey2021 propose a matrix-completion approach that imputes counterfactual outcomes under a low-rank structure. Both methods use information from never-treated controls and not-yet-treated observations of treated units, and conduct inference under a super-population framework.
 
-| Code | v1.3.x behavior | v1.4.0 behavior |
-| --- | --- | --- |
-| `gsynth(...)` (default) | Xu (2017) | Xu (2017)  |
-| `gsynth(..., estimator = "gsynth", EM = TRUE)` | Not available  | Xu (2017) — Gsynth |
-| `gsynth(..., estimator = "ife")` | Xu (2017) — Gsynth | Gobillon & Magnac (2016) — IFE-EM |
-| `gsynth(..., EM = TRUE)` | Gobillon & Magnac (2016) — IFE-EM | Gobillon & Magnac (2016) — IFE-EM (unchanged) |
-| `gsynth(..., estimator = "mc")` | Matrix completion | Matrix completion (unchanged) |
+For a full treatment, see the **fect** [User Manual](https://yiqingxu.org/packages/fect/).
 
-**Notes**: 
+This chapter documents the v1.5.0 wrapper paths for users with existing code that depends on `estimator = "ife"` or `estimator = "mc"`, and shows how to run a placebo test on the resulting fit. The chapter ends with migration recipes that move existing calls to `fect::fect()` directly.
 
-(a) *Backward compatibility*: `gsynth(..., EM = TRUE)` maps to IFE-EM (unless `estimator = "gsynth"`) for backward compatiblity. 
-
-(a) *Migration*: If your existing code uses `estimator = "ife"` with `EM = FALSE` (by default, mapped to Gysnth) and you want to preserve prior results, change it to `estimator = "gsynth"`. The default behavior (no `estimator` argument) is unchanged. 
-
-(b) *Implementation error*: If your existing code uses `estimator = "ife"` with `EM = TRUE`, which maps to IFE-EM, do not use `inference = "parametric"`; a previous version contained an erroneous implementation, which severely underestimates uncertainties. It was removed in v1.3.1.
-
-
-
-## IFE-EM
-
-Starting from v1.4.0, set `estimator = "ife"` to use the IFE-EM approach. Since inference is based on the super-population framework, only `"nonparametric"` or `"jackknife"` inference is allowed.
+## A working IFE-EM fit
 
 ```{r}
 library(gsynth)
@@ -47,42 +31,78 @@ data(gsynth)
 ```
 
 ```{r sim-ife, cache = TRUE}
-system.time(
-out <- gsynth(Y ~ D + X1 + X2, data = simdata,
-              index = c("id", "time"), estimator = "ife",
-              force = "two-way", inference = "nonparametric",
-              se = TRUE, nboots = 500, r = c(0, 5),
-              CV = TRUE, parallel = TRUE, cores = 10)
-)
-print(out)
+out_ife <- gsynth(Y ~ D + X1 + X2, data = simdata,
+                  index = c("id", "time"), estimator = "ife",
+                  force = "two-way", inference = "bootstrap",
+                  se = TRUE, nboots = 500, r = c(0, 5),
+                  CV = TRUE, parallel = TRUE, cores = 16)
+print(out_ife)
 ```
 
 ```{r sim-ife-plot}
-plot(out, main = "Estimated ATT (IFE-EM)")
+plot(out_ife, main = "Estimated ATT (IFE-EM)")
 ```
 
-## Matrix completion
+## A working matrix-completion fit
 
-Set `estimator = "mc"` to use the matrix completion method proposed by @Athey2021. Only `"nonparametric"` or `"jackknife"` inference is allowed.
-
-The option `lambda` controls the tuning parameter. If left blank, a sequence of candidates is generated and tested via built-in cross-validation. Users can set the length of the candidate list with `nlambda`, or supply a custom sequence via `lambda`. The number of folds is set with `k` (e.g. `k = 5`).
+The `lambda` argument controls the regularization parameter. If left unset, a sequence of candidates is generated and selected via cross-validation. Set the candidate-list length with `nlambda`, or supply your own sequence via `lambda`. The number of CV folds is set with `k`.
 
 ```{r sim-mc, cache = TRUE}
-system.time(
-out <- gsynth(Y ~ D + X1 + X2, data = simdata,
-              estimator = "mc", index = c("id", "time"),
-              se = TRUE, nboots = 500, r = c(0, 5),
-              CV = TRUE, force = "two-way",
-              parallel = TRUE, cores = 10,
-              inference = "nonparametric")
-)
+out_mc <- gsynth(Y ~ D + X1 + X2, data = simdata,
+                 estimator = "mc", index = c("id", "time"),
+                 se = TRUE, nboots = 500, r = c(0, 5),
+                 CV = TRUE, force = "two-way",
+                 parallel = TRUE, cores = 16,
+                 inference = "bootstrap")
 ```
 
 ```{r sim-mc-plot}
-plot(out, main = "Estimated ATT (MC)")
+plot(out_mc, main = "Estimated ATT (MC)")
 ```
 
-## Matrix completion on turnout data
+::: {.callout-important}
+
+## Hard gate on parametric × IFE-EM (breaking change in v1.5.0)
+
+In v1.4.0, `inference = "parametric"` combined with `estimator = "ife"` or `"mc"` was silently coerced to bootstrap inference with a warning. **In v1.5.0 this combination errors instead.**
+
+```{r hard-gate, eval = FALSE}
+## v1.4.0 (worked, with a warning):
+gsynth(Y ~ D, data = ..., estimator = "ife",
+       inference = "parametric", se = TRUE, nboots = 200)
+
+## v1.5.0 (errors). Migrate to:
+gsynth(Y ~ D, data = ..., estimator = "ife",
+       inference = "bootstrap", se = TRUE, nboots = 200)
+```
+
+The hard gate matches **fect** v2.2.0+. The reason is that silent coercion can hide an inferential issue from users who deliberately chose IFE-EM: the parametric bootstrap is designed for the small-$N_{tr}$ GSC setting and is not a sensible choice once you switch to a super-population estimator. A hard error forces a conscious choice. For the longer discussion, see the **fect** [User Manual](https://yiqingxu.org/packages/fect/).
+
+:::
+
+## Placebo tests for IFE-EM and MC {#sec-ife-mc-placebo}
+
+The basic placebo workflow is in [Chapter @sec-placebo]. We repeat it here on an IFE-EM fit because the placebo test is especially worth running on these estimators: the EM step blends pre-treatment treated cells into the factor estimates, and the matrix-completion regularizer trades bias for variance, so both can produce non-zero pre-treatment "effects" without a real signal.
+
+```{r placebo-ife, cache = TRUE}
+out_ife_pb <- gsynth(Y ~ D + X1 + X2, data = simdata,
+                     index = c("id", "time"), estimator = "ife",
+                     force = "two-way", CV = FALSE, r = 2,
+                     se = TRUE, inference = "bootstrap",
+                     nboots = 500, parallel = TRUE, cores = 16,
+                     placeboTest = TRUE,
+                     placebo.period = c(-2, 0))
+```
+
+```{r placebo-ife-plot}
+plot(out_ife_pb, main = "Placebo test --- IFE-EM on simdata")
+```
+
+The numeric output for the placebo region is in `out_ife_pb$est.placebo`.
+
+A note on what `gsynth()` does *not* expose: **fect** also has a `carryoverTest` argument that holds out late post-treatment periods to check whether treatment effects persist past the end of the treatment window. That test requires panels with treatment reversals, which the GSC framework does not allow, so `gsynth()` does not accept `carryoverTest`. If you have a panel with reversals and want a carryover test, use `fect::fect()` directly.
+
+## Matrix completion on unbalanced data
 
 Applying matrix completion to the unbalanced `turnout` data:
 
@@ -93,13 +113,99 @@ turnout.ub <- turnout[-c(which(turnout$abb == "WY")[1:15],
 ```
 
 ```{r turnout-mc, cache = TRUE}
-out.mc <- gsynth(turnout ~ policy_edr + policy_mail_in + policy_motor,
-                 min.T0 = 8, data = turnout.ub,
-                 index = c("abb", "year"), estimator = "mc",
-                 se = TRUE, nboots = 1000, seed = 02139)
+out_mc_ub <- gsynth(turnout ~ policy_edr + policy_mail_in + policy_motor,
+                    min.T0 = 8, data = turnout.ub,
+                    index = c("abb", "year"), estimator = "mc",
+                    se = TRUE, inference = "bootstrap",
+                    nboots = 1000, seed = 02139,
+                    parallel = TRUE, cores = 16)
 ```
 
 ```{r turnout-mc-plot}
-plot(out.mc, main = "Estimated ATT (MC)",
+plot(out_mc_ub, main = "Estimated ATT (MC, unbalanced turnout)",
      xlim = c(-10, 5), ylim = c(-10, 20))
 ```
+
+## Migration to fect {#sec-migration}
+
+When v2.0.0 ships (target: late 2026), the IFE-EM and MC paths in `gsynth` will be removed entirely. Migrating now means moving these calls to `fect::fect()`. The substitution is mechanical.
+
+### IFE-EM migration
+
+```{r ife-migration, eval = FALSE}
+## v1.4.0:
+gsynth(Y ~ D + X1 + X2, data = simdata,
+       index = c("id", "time"), estimator = "ife",
+       inference = "bootstrap", se = TRUE,
+       nboots = 200, r = c(0, 5), CV = TRUE,
+       force = "two-way")
+
+## v1.5.0+ (use fect directly):
+fect::fect(Y ~ D + X1 + X2, data = simdata,
+           index = c("id", "time"),
+           method = "ife",
+           time.component.from = "notyettreated",
+           vartype = "bootstrap", se = TRUE,
+           nboots = 200, r = c(0, 5), CV = TRUE,
+           force = "two-way")
+```
+
+### Matrix completion migration
+
+```{r mc-migration, eval = FALSE}
+## v1.4.0:
+gsynth(Y ~ D + X1 + X2, data = simdata,
+       index = c("id", "time"), estimator = "mc",
+       inference = "bootstrap", se = TRUE, nboots = 200,
+       force = "two-way")
+
+## v1.5.0+ (use fect directly):
+fect::fect(Y ~ D + X1 + X2, data = simdata,
+           index = c("id", "time"),
+           method = "mc",
+           time.component.from = "notyettreated",
+           vartype = "bootstrap", se = TRUE, nboots = 200,
+           force = "two-way")
+```
+
+### `EM = TRUE` migration
+
+`EM = TRUE` was an early flag that mapped to IFE-EM. In v1.5.0, the canonical replacement is `fect::fect(method = "ife", ...)` directly:
+
+```{r em-migration, eval = FALSE}
+## v1.4.0:
+gsynth(Y ~ D + X1 + X2, data = simdata,
+       index = c("id", "time"), EM = TRUE,
+       se = TRUE, nboots = 200, r = c(0, 5))
+
+## v1.5.0+:
+fect::fect(Y ~ D + X1 + X2, data = simdata,
+           index = c("id", "time"),
+           method = "ife",
+           time.component.from = "notyettreated",
+           vartype = "bootstrap", se = TRUE,
+           nboots = 200, r = c(0, 5))
+```
+
+### Argument mapping
+
+| `gsynth()` arg | `fect::fect()` equivalent |
+| --- | --- |
+| `inference = "parametric"` | `vartype = "parametric"` |
+| `inference = "nonparametric"` | `vartype = "bootstrap"` |
+| `inference = "bootstrap"` | `vartype = "bootstrap"` |
+| `inference = "jackknife"` | `vartype = "jackknife"` |
+| `weight = "col"` | `W = "col"` |
+| `EM = TRUE` | `method = "ife"`, `time.component.from = "notyettreated"` |
+| `estimator = "ife"` | `method = "ife"`, `time.component.from = "notyettreated"` |
+| `estimator = "mc"` | `method = "mc"`, `time.component.from = "notyettreated"` |
+| `estimator = "gsynth"` | `method = "ife"` (or `"gsynth"`), `time.component.from = "nevertreated"` |
+
+Most other arguments (`CV`, `r`, `force`, `nboots`, `parallel`, `cores`, `seed`, `min.T0`, `alpha`, `normalize`, `tol`) carry over by name.
+
+If you maintain a replication archive that depends on `gsynth(..., estimator = "ife")` or `gsynth(..., estimator = "mc")`, plan for one of two paths:
+
+1. **Pin to gsynth 1.4.0** via the CRAN archive: `remotes::install_version("gsynth", "1.4.0")`.
+2. **Migrate the calls to `fect::fect()`** using the recipes above.
+
+After v2.0.0, bug fixes and feature work for IFE-EM and MC happen exclusively in **fect**.

--- a/tutorial/03-plots.Rmd
+++ b/tutorial/03-plots.Rmd
@@ -1,0 +1,143 @@
+# Plot customization {#sec-plots}
+
+```{r setup, include=FALSE}
+knitr::opts_chunk$set(echo = TRUE, message = FALSE, warning = FALSE,
+                      fig.width = 10, fig.height = 7)
+```
+
+```{r}
+library(gsynth)
+data(gsynth)
+```
+
+The `plot.gsynth()` method passes most arguments through to **fect**'s `plot.fect()`. This chapter collects the customization options most commonly used with `gsynth` fits, including the modern visual recipe introduced in **fect** v2.3.x and the new `legacy.style`, `highlight`, and `highlight.fill` arguments available from v1.5.0.
+
+For this chapter we use a fitted block-DID example:
+
+```{r plots-fit, cache = TRUE}
+## Pin r = 2 so the factors / loadings examples below have a
+## non-trivial factor structure to plot (CV may pick r = 0 on the
+## bundled simdata under v1.5.0 defaults).
+out <- gsynth(Y ~ D + X1 + X2, data = simdata,
+              index = c("id", "time"), force = "two-way",
+              r = 2, CV = FALSE, se = TRUE,
+              inference = "parametric", nboots = 200,
+              parallel = FALSE)
+```
+
+## Modern vs legacy visual recipe
+
+Starting in **fect** v2.3.1, the default `plot.fect()` recipe was overhauled: white panel, dashed treatment-onset vertical line at `x = 0.5`, smaller publication-sized axis text, compact legends, and pre/post grayscale color contrast. `gsynth` inherits this recipe automatically.
+
+```{r modern-default}
+plot(out, type = "gap")
+```
+
+To reproduce figures from earlier submissions exactly (where the visual recipe must match the prior version), pass `legacy.style = TRUE`:
+
+```{r legacy-style}
+plot(out, type = "gap", legacy.style = TRUE)
+```
+
+`theme.bw = FALSE` (the original ggplot2 default theme) is soft-deprecated and slated for removal in **fect** v2.5.0; passing it now emits a one-time-per-session message.
+
+## The highlight API
+
+For placebo and carryover tests, the modern recipe uses colored-glyph highlighting on the test periods. The behavior is controlled by two arguments:
+
+- `highlight`: which test types receive highlighting. `NULL` (default) auto-detects from the fit. `TRUE` enables across all types; `FALSE` disables. A character subset of `c("placebo", "carryover", "carryover.rm")` selects specific types.
+- `highlight.fill`: when `TRUE`, draws a lightened-tone background rectangle behind each highlighted period (slide / talk style). When `FALSE` (default), uses glyph-only highlighting that survives grayscale printing.
+
+```{r highlight-default}
+plot(out, type = "gap")
+```
+
+```{r highlight-fill, eval = FALSE}
+## With background rectangles for talk slides:
+plot(out, type = "gap", highlight.fill = TRUE)
+```
+
+## Counterfactual plots
+
+The counterfactual plot type (`"counterfactual"` or `"ct"`) shows the observed treated-unit trajectory against the imputed counterfactual:
+
+```{r ct-default}
+plot(out, type = "counterfactual", raw = "none", main = "")
+```
+
+Without post-treatment shading:
+
+```{r ct-no-shade}
+plot(out, type = "ct", raw = "none", main = "",
+     shade.post = FALSE)
+```
+
+With quantile bands (5th–95th percentile of the control-pool raw outcomes):
+
+```{r ct-band}
+plot(out, type = "counterfactual", raw = "band",
+     xlab = "Time", ylim = c(-5, 35))
+```
+
+With all raw control trajectories overlaid:
+
+```{r ct-all}
+plot(out, type = "counterfactual", raw = "all")
+```
+
+Unit-level counterfactuals via `id`:
+
+```{r ct-unit-1}
+plot(out, type = "counterfactual", id = 102)
+```
+
+```{r ct-unit-2}
+plot(out, type = "counterfactual", id = 104,
+     raw = "band", ylim = c(-10, 30))
+```
+
+```{r ct-unit-3}
+plot(out, type = "counterfactual", id = 105,
+     raw = "all", legendOff = TRUE)
+```
+
+## Factors and loadings
+
+```{r factors, results='hide'}
+plot(out, type = "factors", xlab = "Time")
+```
+
+```{r loadings, fig.height = 5, results='hide'}
+plot(out, type = "loadings")
+```
+
+`type = "loading.overlap"` shows the treated and control loadings in the first two factor dimensions, with the convex hull of control loadings shaded. Treated points outside the hull indicate that the GSC counterfactual extrapolates beyond the observed support. See [Chapter @sec-gsynth] §Loading-overlap diagnostic for the workflow.
+
+```{r loading-overlap, fig.height = 5, results='hide'}
+plot(out, type = "loading.overlap")
+```
+
+## Raw data and missing-data plots
+
+```{r raw}
+plot(out, type = "raw")
+```
+
+The `"missing"` plot is most useful on unbalanced panels:
+
+```{r missing, eval = FALSE}
+plot(out, type = "missing")
+```
+
+White cells are missing observations; gray with red dots are observations removed due to insufficient pre-treatment periods. The matrix is also available in `out$obs.missing`, where `0` = missing, `1` = control, `2` = treated (pre), `3` = treated (post), `4` = treated (removed).
+
+## Customizing axes and titles
+
+Standard arguments control axes and the title:
+
+```{r ct-customized}
+plot(out, type = "gap", ylim = c(-10, 12), xlab = "Period",
+     main = "My GSynth Plot")
+```
+
+Legend can be suppressed with `legendOff = TRUE`. Axis labels rotate automatically when there are many time periods; force with `axis.adjust = TRUE`.

--- a/tutorial/_quarto.yml
+++ b/tutorial/_quarto.yml
@@ -10,6 +10,7 @@ book:
     - index.qmd
     - 01-gsynth.Rmd
     - 02-ife-mc.Rmd
+    - 03-plots.Rmd
     - aa-changelog.Rmd
     - references.qmd
 
@@ -27,8 +28,10 @@ format:
     code-fold: false
     code-tools: true
     code-link: true
+    fig-format: svg
 
 knitr:
   opts_chunk:
     collapse: true
     comment: "#>"
+    dev: svg

--- a/tutorial/aa-changelog.Rmd
+++ b/tutorial/aa-changelog.Rmd
@@ -1,10 +1,21 @@
 # Changelog {#sec-changelog .unnumbered}
 
+## v1.5.0
+
+(2026-05-04) Catch-up release for **fect** v2.4.x. Requires `fect (>= 2.4.2)`.
+
+* **Diagnostics**: placebo test (`placeboTest = TRUE`, `placebo.period`) and loading-overlap plot (`plot(fit, type = "loading.overlap")`). See [Chapter @sec-gsynth].
+* **Inference**: new `ci.method` argument --- `"normal"` (default; Wald) or `"basic"` ---reflected-pivot bootstrap, @DavisonHinkley1997.
+* **Plot recipe**: modern visual style from **fect** v2.3.x, with new arguments `legacy.style`, `highlight`, `highlight.fill`. See [Chapter @sec-plots].
+* **CV defaults**: rolling-window (`cv.method = "rolling"`, `cv.prop = 0.1`, `cv.buffer = 1`); default `k` is now 20.
+* **Soft-deprecated paths**: `estimator = "ife"`, `estimator = "mc"`, `EM = TRUE`, and `effect()`. For these methods --- and for post-hoc estimands (cumulative ATT, APTT, log-ATT) --- use `fect::fect()` and `fect::estimand()` directly. Migration recipes in [Chapter @sec-ife-mc].
+* **Guardrail**: `inference = "parametric"` with `estimator = "ife"` or `"mc"` now errors instead of silently falling back to nonparametric bootstrap.
+
 ## v1.4.0
 
 (2026-03-27) CRAN release.
 
-* **Breaking change**: `estimator` parameter now maps directly to estimation methods. `estimator = "gsynth"` (new default) uses @Xu2017; `estimator = "ife"` uses @Gobillon2016 EM algorithm; `estimator = "mc"` uses @Athey2021 matrix completion. The legacy `EM = TRUE` parameter is equivalent to `estimator = "ife"`. 
+* **Breaking change**: `estimator` parameter now maps directly to estimation methods. `estimator = "gsynth"` (new default) uses @Xu2017; `estimator = "ife"` uses @Gobillon2016 EM algorithm; `estimator = "mc"` uses @Athey2021 matrix completion. The legacy `EM = TRUE` parameter is equivalent to `estimator = "ife"`.
 * Fixed loadings plot warnings (upstream fix in **fect**).
 * Replaced pkgdown vignette with Quarto book tutorial.
 

--- a/tutorial/index.qmd
+++ b/tutorial/index.qmd
@@ -1,19 +1,44 @@
 # Welcome {.unnumbered}
 
-This manual serves as a user guide for the **gsynth** package in R. 
+This manual serves as a user guide for the **gsynth** package in R.
 
-Starting from v1.3.0, **gsynth** becomes a wrapper of **fect**. We recommend users consult the **fect** [User Manual](https://yiqingxu.org/packages/fect/) for the most up-to-date features. We maintain **gsynth** for backward compatibility. For the technical details, see @Xu2017.
+Starting from v1.3.0, **gsynth** becomes a wrapper of **fect**. We recommend users consult the **fect** [User Manual](https://yiqingxu.org/packages/fect/) for the most up-to-date features. We maintain **gsynth** for backward compatibility. For the technical details of the GSC estimator, see @Xu2017.
+
+::: {.callout-tip}
+
+## What's new in v1.5.0
+
+- **fect 2.4.x catch-up.** 
+  - new rolling-window cross-validation defaults (`cv.method = "rolling"`, `k = 20`); 
+  - new `ci.method` argument for the confidence intervals reported in `est.*` slots; 
+  - new `placeboTest` and `placebo.period` arguments for placebo testing; 
+  - new `legacy.style`, `highlight`, and `highlight.fill` arguments on `plot.gsynth()`;
+  - loading-overlap plot type available via `plot(fit, type = "loading.overlap")`.
+- **Soft-deprecated paths.** 
+  - `estimator = "ife"` (IFE-EM), `estimator = "mc"` (matrix completion), `EM = TRUE`, and `effect()`. Each emits a one-time-per-session deprecation message. 
+  - For IFE-EM, matrix completion, and post-hoc estimands (cumulative ATT, APTT, log-ATT), use [`fect::fect()`](https://yiqingxu.org/packages/fect/) and `fect::estimand()` directly. 
+- **Breaking change.** `inference = "parametric"` with `estimator = "ife"` or `"mc"` now errors instead of silently coercing to bootstrap. See [Chapter @sec-ife-mc].
+
+:::
 
 ## Installation
 
-```{r install-cran, eval = FALSE}
-# From CRAN
-install.packages("gsynth")
+**gsynth** v1.5.0 requires **fect** `>= 2.4.2`. Until **fect** v2.4.2 is on CRAN, install both the **fect** development branch and **gsynth** from GitHub:
+
+```{r install-fect-dev, eval = FALSE}
+# Up-to-date fect from the dev branch (>= 2.4.2)
+devtools::install_github("xuyiqing/fect", ref = "dev")
 ```
 
 ```{r install-github, eval = FALSE, message = FALSE, warning = FALSE}
-# Development version
+# gsynth development version
 devtools::install_github("xuyiqing/gsynth")
+```
+
+Once **fect** v2.4.2 is on CRAN, the standard install will suffice:
+
+```{r install-cran, eval = FALSE}
+install.packages("gsynth")
 ```
 
 ```{r check-version}
@@ -26,17 +51,17 @@ installed.packages()["gsynth", "Version"]
 library(gsynth)
 ```
 
-## Quick-reference
+## Quick reference
 
-**gsynth** has one main function, `gsynth()`, which estimates causal effects using interactive fixed-effect models. Three estimation methods are available:
+**gsynth** has one main function, `gsynth()`, which estimates causal effects using interactive fixed-effect models. Three estimation methods are nominally available, but only the GSC path is recommended in v1.5.0+:
 
-| `estimator =` | Method | Algorithm | Reference |
+| `estimator =` | Status | Method | Reference |
 | --- | --- | --- | --- |
-| `"gsynth"` (default) | Generalized Synthetic Control | Factors estimated from control group only | @Xu2017 |
-| `"ife"` | Interactive Fixed Effects with EM | EM algorithm using treated units' pre-treatment data | @Gobillon2016 |
-| `"mc"` | Matrix Completion | Nuclear norm regularization | @Athey2021 |
+| `"gsynth"` (default) | **recommended** | Generalized Synthetic Control | @Xu2017 |
+| `"ife"` | soft-deprecated; use `fect::fect(method = "ife", ...)` | IFE-EM | @Gobillon2016 |
+| `"mc"` | soft-deprecated; use `fect::fect(method = "mc", ...)` | Matrix completion | @Athey2021 |
 
-The legacy `EM = TRUE` parameter is equivalent to `estimator = "ife"`.
+The legacy `EM = TRUE` parameter is also soft-deprecated and equivalent to `estimator = "ife"`.
 
 ### Key arguments
 
@@ -45,23 +70,31 @@ The legacy `EM = TRUE` parameter is equivalent to `estimator = "ife"`.
 | `formula` | formula | `Y ~ D + X1 + X2`; first RHS variable is the treatment |
 | `data` | data.frame | Long-format panel data |
 | `index` | character(2) | `c("unit_var", "time_var")` |
-| `estimator` | character | `"gsynth"` / `"ife"` / `"mc"` |
+| `estimator` | character | `"gsynth"` (recommended); `"ife"` / `"mc"` soft-deprecated |
 | `force` | character | `"none"` / `"unit"` / `"time"` / `"two-way"` |
 | `r` | integer(2) | Range for number of factors, e.g. `c(0, 5)` |
 | `CV` | logical | Cross-validation to select number of factors |
+| `cv.method` | character | `"rolling"` (default) or `"block"` |
+| `cv.prop` | numeric | Per-fold unit-sampling fraction (default 0.1) |
+| `cv.buffer` | integer | Past-side buffer for rolling CV (default 1) |
+| `k` | integer | CV folds (default 20 in v1.5.0+) |
+| `time.component.from` | character | `"nevertreated"` (GSC) or `"notyettreated"` (IFE-EM/MC) |
 | `se` | logical | Compute uncertainty estimates |
 | `inference` | character | `"parametric"` / `"nonparametric"` / `"jackknife"` |
-| `nboots` | integer | Number of bootstrap runs |
+| `ci.method` | character | `"normal"` (default; Wald) or `"basic"` (reflected pivot). New in v1.5.0. |
+| `nboots` | integer | Number of bootstrap runs (default 200; bump to 1000+ for tail-quantile CIs) |
+| `placeboTest` | logical | Hold out pre-treatment periods as placebo. New in v1.5.0. |
+| `placebo.period` | integer | Event-time periods used for the placebo block, e.g. `c(-2, 0)` |
+| `weight`, `W.est`, `W.agg` | character | Weight column(s); per-role variants for outcome fit / aggregation |
 | `parallel` | logical | Enable parallel computing |
 | `cores` | integer | Number of cores (default: auto-detect) |
 | `min.T0` | integer | Minimum pre-treatment periods for treated units |
 
-
-
 ## Organization
 
-- [Chapter @sec-gsynth] — Generalized Synthetic Control (block DID, staggered DID, unbalanced panels)
-- [Chapter @sec-ife-mc] — IFE-EM and Matrix Completion methods
+- [Chapter @sec-gsynth] --- Generalized Synthetic Control: block DID, inference, placebo test, loading-overlap diagnostic, staggered DID, unbalanced panels
+- [Chapter @sec-ife-mc] --- IFE-EM and matrix completion (soft-deprecated); placebo test for these methods; migration to `fect::fect()`
+- [Chapter @sec-plots] --- Plot customization, modern theme, highlight API, plot types (counterfactual, factors, loadings, loading-overlap, raw, missing)
 
 ## Contributors
 
@@ -87,6 +120,8 @@ To cite the **gsynth** package, please use:
   year = {2017}
 }
 ```
+
+For technical background on the v2.0–v2.4 changes in **fect** (which `gsynth` v1.5.0 inherits), see the **fect** [User Manual](https://yiqingxu.org/packages/fect/).
 
 ## Report Bugs
 

--- a/tutorial/references.bib
+++ b/tutorial/references.bib
@@ -1,1 +1,42 @@
-@ARTICLE{Xu2017,  title     = "Generalized Synthetic Control Method: Causal Inference with               Interactive Fixed Effects Models",  author    = "Xu, Yiqing",  journal   = "Political Analysis",  volume    =  25,  number    =  1,  pages     = "57-76",  year      =  2017}@ARTICLE{Gobillon2016,  title   = "Regional Policy Evaluation: Interactive Fixed Effects and             Synthetic Controls",  author  = "Gobillon, Laurent and Magnac, Thierry",  journal = "Review of Economics and Statistics",  volume  =  98,  number  =  3,  pages   = "535--551",  year    =  2016}@ARTICLE{Athey2021,  title   = "Matrix Completion Methods for Causal Panel Data Models",  author  = "Athey, Susan and Bayati, Mohsen and Doudchenko, Nikolay and             Imbens, Guido and Khosravi, Khashayar",  journal = "Journal of the American Statistical Association",  volume  = "forthcoming",  year    =  2021}
+@ARTICLE{Xu2017,
+  title   = "Generalized Synthetic Control Method: Causal Inference with Interactive Fixed Effects Models",
+  author  = "Xu, Yiqing",
+  journal = "Political Analysis",
+  volume  =  25,
+  number  =  1,
+  pages   = "57-76",
+  year    =  2017
+}
+
+@ARTICLE{Gobillon2016,
+  title   = "Regional Policy Evaluation: Interactive Fixed Effects and Synthetic Controls",
+  author  = "Gobillon, Laurent and Magnac, Thierry",
+  journal = "Review of Economics and Statistics",
+  volume  =  98,
+  number  =  3,
+  pages   = "535--551",
+  year    =  2016
+}
+
+@ARTICLE{Athey2021,
+  title   = "Matrix Completion Methods for Causal Panel Data Models",
+  author  = "Athey, Susan and Bayati, Mohsen and Doudchenko, Nikolay and Imbens, Guido and Khosravi, Khashayar",
+  journal = "Journal of the American Statistical Association",
+  volume  = "forthcoming",
+  year    =  2021
+}
+
+@ARTICLE{ChenRoth2024,
+  title   = "Logs with Zeros? Some Problems and Solutions",
+  author  = "Chen, Jiafeng and Roth, Jonathan",
+  journal = "Quarterly Journal of Economics",
+  year    =  2024
+}
+
+@BOOK{DavisonHinkley1997,
+  title     = "Bootstrap Methods and their Application",
+  author    = "Davison, A. C. and Hinkley, D. V.",
+  publisher = "Cambridge University Press",
+  series    = "Cambridge Series in Statistical and Probabilistic Mathematics",
+  year      =  1997
+}


### PR DESCRIPTION
## Summary

v1.5.0 catches **gsynth** up to **fect** 2.4.x. Requires `fect (>= 2.4.2)`.

- **Diagnostics**: placebo test (`placeboTest`, `placebo.period`) and loading-overlap plot (`plot(fit, type = "loading.overlap")`).
- **Inference**: new `ci.method` argument — `"normal"` (Wald, default) or `"basic"` (reflected-pivot bootstrap, Davison-Hinkley 1997).
- **Plot recipe**: modern visual style from fect 2.3.x; new `legacy.style`, `highlight`, `highlight.fill` arguments.
- **CV defaults**: rolling-window (`cv.method = "rolling"`, `cv.prop = 0.1`, `cv.buffer = 1`); default `k` bumped 5 to 20.
- **Soft-deprecated**: `estimator = "ife"`, `estimator = "mc"`, `EM = TRUE`, `effect()`. Recommended path is `fect::fect()` / `fect::estimand()`.
- **Guardrail**: `inference = "parametric"` with `estimator = "ife"`/`"mc"` now errors instead of silently coercing to bootstrap.

Quarto book restructured to 3 chapters + changelog + references; ch1 adds a diagnostics callout, factor/loading plots for both `simdata` and `turnout`, and the loading-overlap diagnostic on the `turnout` fit. Index page leads with fect-dev install until fect 2.4.2 is on CRAN.

## Test plan

- [x] `devtools::install()` clean
- [x] Quarto book renders 6/6 HTML, 38 SVGs, 0 errors
- [x] CI green on PR
- [ ] CRAN submission held until fect 2.4.2 is on CRAN

🤖 Generated with [Claude Code](https://claude.com/claude-code)