### PR TITLE
Forward `weight` to fect::fect() so weighted ATT is actually weighted

### DIFF
--- a/R/default.R
+++ b/R/default.R
@@ -76,7 +76,7 @@ gsynth <- function(formula = NULL,data, # a data frame (long-form)
       }
     }
     output <- fect::fect(formula = formula, data = data, method = method, Y = Y, D = D, X = X,
-        na.rm = na.rm, index = index, cl = cl,
+        na.rm = na.rm, index = index, cl = cl, W = weight,
         force = force, r = r, lambda = lambda, nlambda = nlambda, CV = CV,
         criterion = criterion, k = k, se = se, nboots = nboots, vartype = inference,
         parallel = parallel, cores = cores, tol = tol, seed = seed, min.T0 = min.T0,

--- a/tests/testthat/test-weight.R
+++ b/tests/testthat/test-weight.R
@@ -1,0 +1,39 @@
+test_that("weight is passed through to the estimator", {
+  skip_on_cran()
+
+  # Treatment effects differ across treated units; the weights favour the
+  # large-effect half heavily. A weighted ATT must therefore differ from the
+  # unweighted one. Before `weight` was forwarded these were bit-identical.
+  set.seed(42)
+  N <- 30; T <- 16; T0 <- 12; ntr <- 10
+
+  unit <- rep(seq_len(N), each = T)
+  time <- rep(seq_len(T), times = N)
+  f1 <- rnorm(T); l1 <- rnorm(N)
+
+  treated <- seq_len(ntr)
+  D <- as.integer(unit %in% treated & time > T0)
+
+  eff <- rep(0, N)
+  eff[treated[1:(ntr / 2)]] <- 1
+  eff[treated[(ntr / 2 + 1):ntr]] <- 9
+
+  Y <- l1[unit] * f1[time] + eff[unit] * D + rnorm(N * T, sd = 0.2)
+  wt <- ifelse(unit %in% treated[(ntr / 2 + 1):ntr], 50, 1)
+  dat <- data.frame(unit, time, Y, D, wt)
+
+  args <- list(formula = Y ~ D, data = dat, index = c("unit", "time"),
+               force = "two-way", r = 1, CV = FALSE, se = FALSE,
+               parallel = FALSE)
+
+  plain <- suppressWarnings(suppressMessages(do.call(gsynth, args)))
+  wtd <- suppressWarnings(suppressMessages(
+    do.call(gsynth, c(args, list(weight = "wt")))))
+
+  expect_false(isTRUE(all.equal(plain$att.avg, wtd$att.avg)))
+
+  # and it should move toward the weighted truth, not merely differ
+  truth_unwt <- mean(eff[treated])
+  truth_wtd <- weighted.mean(eff[treated], ifelse(seq_len(ntr) > ntr / 2, 50, 1))
+  expect_lt(abs(wtd$att.avg - truth_wtd), abs(wtd$att.avg - truth_unwt))
+})


### PR DESCRIPTION
`gsynth()` accepts a `weight` argument, documented as "a string specifying the weighting variable (if any) to estimate the weighted average treatment effect". Since the 1.4.0 refactor that delegates estimation to `fect::fect()`, that argument is no longer forwarded, so it silently has no effect — the returned ATT is unweighted.

The word `weight` appears exactly once in the package's R source, in the formal declaration:

```
$ grep -rn "weight" R/
R/default.R:30:                           weight = NULL,
```

## Reproduction

Treatment effects differ across treated units; the weights favour the large-effect half 50:1, so the weighted ATT should be far above the unweighted one.

```r
library(gsynth)
set.seed(42)
N <- 40; T <- 20; T0 <- 15; ntr <- 10
unit <- rep(seq_len(N), each = T); time <- rep(seq_len(T), times = N)
f1 <- rnorm(T); f2 <- rnorm(T); l1 <- rnorm(N); l2 <- rnorm(N)
treated <- seq_len(ntr)
D <- as.integer(unit %in% treated & time > T0)
eff <- rep(0, N)
eff[treated[1:(ntr/2)]] <- 1
eff[treated[(ntr/2+1):ntr]] <- 9
Y <- l1[unit]*f1[time] + l2[unit]*f2[time] + eff[unit]*D + rnorm(N*T, sd = 0.2)
wt <- ifelse(unit %in% treated[(ntr/2+1):ntr], 50, 1)
dat <- data.frame(unit, time, Y, D, wt)

a <- gsynth(Y ~ D, data = dat, index = c("unit","time"),
            force = "two-way", r = 2, CV = FALSE, se = FALSE, parallel = FALSE)
b <- gsynth(Y ~ D, data = dat, index = c("unit","time"), weight = "wt",
            force = "two-way", r = 2, CV = FALSE, se = FALSE, parallel = FALSE)

a$att.avg   # 5.004228
b$att.avg   # 5.004228  -- identical
```

True unweighted ATT is 5.0; true weighted ATT is about 8.84. On 1.4.0 the weighted call returns 5.00, with no warning.

For context, `weight` was honoured in 1.2.1 (`Wname <- weight` in `R/default.R`, with the weight column carried through the data subsetting), so this looks like an oversight in the `fect` delegation rather than an intentional removal. Issues #18 and #73 suggest the option has users.

## Change

One line — `fect::fect()` already has the corresponding parameter, `W`, documented as "a string giving the column name of a weight variable … suitable for survey or sample weights":

```diff
     output <- fect::fect(formula = formula, data = data, method = method, Y = Y, D = D, X = X,
-        na.rm = na.rm, index = index, cl = cl,
+        na.rm = na.rm, index = index, cl = cl, W = weight,
```

With it, the reproduction above returns **8.784774** for the weighted call against a true weighted ATT of ~8.84, and 5.004228 for the unweighted one.

Added `tests/testthat/test-weight.R`, which asserts the two differ and that the weighted estimate lands nearer the weighted truth. It fails on current `master` (2 failures) and passes with the change.

## What I could not verify

I have confirmed `fect`'s `W` is documented for this purpose and that it produces the expected weighted estimand on the example above. I have **not** verified that it is numerically identical to the weighting 1.2.1 implemented internally — if the two differ in how weights enter normalisation or the factor step, you would know that far better than I would. Happy to adjust if you would rather this warned instead of silently changing the estimand for people who currently pass `weight`.

## Unrelated observation

The test suite does not currently run on `master`: `tests/testthat/*.R` call `data(simdata, package = "gsynth")`, but the data ships as `data/gsynth.RData`, so with `LazyData: true` the lookup by individual name fails and all 19 tests error with "object 'simdata' not found". `gsynth::simdata` itself resolves fine. I left this alone to keep the diff focused, but flagging it since it means CI would not catch regressions. The test I added builds its own data, so it runs regardless.
